### PR TITLE
Support of output with full 16-bit precision

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ You can download the app from the [Mac App Store](https://burst.photo/download/)
 - [x] align+merge running in pure Metal
 - [x] native Intel, Apple Silicon support
 
-# TODO
-- [ ] super-resolution
+# List of Ideas
+- [ ] add super-resolution algorithm
 - [ ] fix progressbar getting stuck loading the first image
 
 Please feel free to contribute to any of these features or suggest other features.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ You can download the app from the [Mac App Store](https://burst.photo/download/)
 - [x] non-Bayer sensor support (beta)
 - [x] support for bursts with bracketed exposure
 - [x] optional exposure correction to improve tonality in the shadows
+- [x] optional output with full 16 bit precision
 - [x] preserves lens profiles
 - [x] hot pixel suppression
 - [x] multi-threaded image loading

--- a/burstphoto/App.swift
+++ b/burstphoto/App.swift
@@ -7,6 +7,7 @@ class AppSettings: ObservableObject {
     @AppStorage("merging_algorithm") var merging_algorithm: String = "Fast"
     @AppStorage("noise_reduction") var noise_reduction: Double = 13.0
     @AppStorage("exposure_control") var exposure_control: String = " Linear (full bit range)"
+    @AppStorage("output_bit_depth") var output_bit_depth: String = "Native"
 }
 
 class AppDelegate: NSObject, NSApplicationDelegate {

--- a/burstphoto/ContentView.swift
+++ b/burstphoto/ContentView.swift
@@ -413,8 +413,8 @@ struct MyDropDelegate: DropDelegate {
         
         // set simplified value for output bit depth
         let output_bit_depth_dict = [
-            "Native"                       : "Native",
-            "Scale to 16 bit"              : "16Bit",
+            "Native"          : "Native",
+            "Scale to 16 bit" : "16Bit",
         ]
         let output_bit_depth_short = output_bit_depth_dict[settings.output_bit_depth]!
         

--- a/burstphoto/align.metal
+++ b/burstphoto/align.metal
@@ -1811,6 +1811,7 @@ kernel void correct_hotpixels(texture2d<float, access::read> average_texture [[t
                               constant int& black_level3 [[buffer(4)]],
                               constant float& hot_pixel_threshold [[buffer(5)]],
                               constant float& hot_pixel_multiplicator [[buffer(6)]],
+                              constant float& correction_strength [[buffer(7)]],
                               uint2 gid [[thread_position_in_grid]]) {
        
     int const x = gid.x+2;
@@ -1859,7 +1860,7 @@ kernel void correct_hotpixels(texture2d<float, access::read> average_texture [[t
         sum2      += in_texture.read(uint2(x+0, y+2)).r;
         
         // calculate weight for blending to have a smooth transition for not so obvious hot pixels
-        float const weight = 0.5f*min(hot_pixel_multiplicator*(pixel_ratio-hot_pixel_threshold), 2.0f);
+        float const weight = correction_strength*0.5f*min(hot_pixel_multiplicator*(pixel_ratio-hot_pixel_threshold), 2.0f);
         
         // blend values and replace hot pixel value
         out_texture.write(weight*0.25f*sum2 + (1.0f-weight)*in_texture.read(uint2(x, y)).r, uint2(x, y));

--- a/burstphoto/align.metal
+++ b/burstphoto/align.metal
@@ -34,13 +34,36 @@ kernel void texture_uint16_to_float(texture2d<uint, access::read> in_texture [[t
 kernel void convert_float_to_uint16(texture2d<float, access::read> in_texture [[texture(0)]],
                                     texture2d<uint, access::write> out_texture [[texture(1)]],
                                     constant int& white_level [[buffer(0)]],
+                                    constant int& black_level0 [[buffer(1)]],
+                                    constant int& black_level1 [[buffer(2)]],
+                                    constant int& black_level2 [[buffer(3)]],
+                                    constant int& black_level3 [[buffer(4)]],
+                                    constant float& color_factor0 [[buffer(5)]],
+                                    constant float& color_factor1 [[buffer(6)]],
+                                    constant float& color_factor2 [[buffer(7)]],
+                                    constant int& factor_16bit [[buffer(8)]],
                                     uint2 gid [[thread_position_in_grid]]) {
+    int const x = gid.x*2;
+    int const y = gid.y*2;
     
-    int out_value = int(round(in_texture.read(gid).r));
+    // load args
+    float4 const black_level = float4(black_level0, black_level1, black_level2, black_level3);
     
+    // extract pixel values of 2x2 super pixel
+    float4 pixel_value = float4(in_texture.read(uint2(x,   y)).r,
+                                in_texture.read(uint2(x+1, y)).r,
+                                in_texture.read(uint2(x,   y+1)).r,
+                                in_texture.read(uint2(x+1, y+1)).r);
+    
+    // apply potential scaling to 16 bit and convert to integer
+    int4 out_value = int4(round((pixel_value - black_level)*factor_16bit + black_level));
     out_value = clamp(out_value, 0, min(white_level, int(UINT16_MAX_VAL)));
     
-    out_texture.write(uint(out_value), gid);
+    // write back into texture
+    out_texture.write(uint(out_value[0]), uint2(x,   y));
+    out_texture.write(uint(out_value[1]), uint2(x+1, y));
+    out_texture.write(uint(out_value[2]), uint2(x,   y+1));
+    out_texture.write(uint(out_value[3]), uint2(x+1, y+1));
 }
 
 
@@ -1923,8 +1946,9 @@ kernel void correct_exposure(texture2d<float, access::read> final_texture_blurre
     // use luminance estimated as the binomial weighted mean pixel value in a 3x3 window around the main pixel
     // apply correction with color factors to reduce clipping of the green color channel
     float luminance_before = final_texture_blurred.read(gid).r;
-    luminance_before = clamp((luminance_before-black_level_mean)/(rescale_factor*color_factor_mean), 0.0f, 1.0f);
-    
+    //luminance_before = clamp((luminance_before-black_level_mean)/(rescale_factor*color_factor_mean), 1.0f/rescale_factor, 1.0f);
+    luminance_before = clamp((luminance_before-black_level_mean)/(rescale_factor*color_factor_mean), 1e-12, 1.0f);
+        
     // apply gains
     float luminance_after0 = linear_gain * gain0 * luminance_before;
     float luminance_after1 = linear_gain * gain1 * luminance_before;

--- a/burstphoto/align.swift
+++ b/burstphoto/align.swift
@@ -208,6 +208,13 @@ func perform_denoising(image_urls: [URL], progress: ProcessingProgress, merging_
     // convert images from uint16 to float16
     textures = textures.map{texture_uint16_to_float($0)}
      
+    // check that the comparison image has the same resolution as the reference image
+    for comp_idx in 0..<textures.count {
+        if (textures[ref_idx].width != textures[comp_idx].width) || (textures[ref_idx].height != textures[comp_idx].height) {
+            throw AlignmentError.inconsistent_resolutions
+        }
+    }
+    
     // set the tile size for the alignment
     let tile_size_dict = [
         "Small": 16,
@@ -466,11 +473,6 @@ func align_merge_spatial_domain(progress: ProcessingProgress, ref_idx: Int, mosa
             
         // set comparison texture
         let comp_texture = extend_texture(textures[comp_idx], pad_align_x, pad_align_x, pad_align_y, pad_align_y)
-        
-        // check that the comparison image has the same resolution as the reference image
-        if (ref_texture.width != comp_texture.width) || (ref_texture.height != comp_texture.height) {
-            throw AlignmentError.inconsistent_resolutions
-        }
      
         let black_level_mean = 0.25*Double(black_level[comp_idx*4+0] + black_level[comp_idx*4+1] + black_level[comp_idx*4+2] + black_level[comp_idx*4+3])
         color_factors3 = [color_factors[comp_idx*3+0], color_factors[comp_idx*3+1], color_factors[comp_idx*3+2]]
@@ -598,11 +600,6 @@ func align_merge_frequency_domain(progress: ProcessingProgress, shift_left_not_r
          
         // set and extend comparison texture
         let comp_texture = extend_texture(textures[comp_idx], pad_left, pad_right, pad_top, pad_bottom)
-        
-        // check that the comparison image has the same resolution as the reference image
-        if (ref_texture.width != comp_texture.width) || (ref_texture.height != comp_texture.height) {
-            throw AlignmentError.inconsistent_resolutions
-        }
         
         let black_level_mean = 0.25*Double(black_level[comp_idx*4+0] + black_level[comp_idx*4+1] + black_level[comp_idx*4+2] + black_level[comp_idx*4+3])
         color_factors3 = [color_factors[comp_idx*3+0], color_factors[comp_idx*3+1], color_factors[comp_idx*3+2]]

--- a/burstphoto/align.swift
+++ b/burstphoto/align.swift
@@ -1632,7 +1632,7 @@ func correct_hotpixels(_ textures: [MTLTexture], _ black_level: [Int], _ ISO_exp
         for comp_idx in 0..<textures.count {
             correction_strength += ISO_exposure_time[comp_idx]
         }
-        correction_strength = (min(max(correction_strength/sqrt(Double(textures.count)) * (noise_reduction==23.0 ? 0.5 : 1.0), 20.0), 100.0)-20.0)/80.0
+        correction_strength = (min(max(correction_strength/sqrt(Double(textures.count)) * (noise_reduction==23.0 ? 0.25 : 1.00), 5.0), 80.0)-5.0)/75.0
     }
     
     // only apply hot pixel correction if correction strength is larger than 0.001

--- a/burstphoto/align.swift
+++ b/burstphoto/align.swift
@@ -1623,8 +1623,6 @@ func correct_hotpixels(_ textures: [MTLTexture], _ black_level: [Int], _ ISO_exp
         correction_strength = (min(max(correction_strength/sqrt(Double(textures.count)) * (noise_reduction==23.0 ? 0.5 : 1.0), 20.0), 100.0)-20.0)/80.0
     }
     
-    print(correction_strength)
-    
     // only apply hot pixel correction if correction strength is larger than 0.001
     if correction_strength > 0.001 {
     

--- a/burstphoto/align.swift
+++ b/burstphoto/align.swift
@@ -331,9 +331,21 @@ func perform_denoising(image_urls: [URL], progress: ProcessingProgress, merging_
     // set output location
     let in_url = dng_urls[ref_idx]
     let in_filename = in_url.deletingPathExtension().lastPathComponent
-    // the value of the noise reduction strength is written into the filename
-    let suffix_merging = merging_algorithm == "Higher quality" ? "q" : "f"
-    let out_filename = in_filename + (noise_reduction==23.0 ? "_merged_avg.dng" : "_merged_" + suffix_merging + "\(Int(noise_reduction+0.5)).dng")
+    // adapt output filename with merging algorithm and noise reduction setting
+    var suffix_merging = (merging_algorithm == "Higher quality" ? "q" : "f")
+    suffix_merging = (noise_reduction==23.0 ? "_merged_avg" : "_merged_" + suffix_merging + "\(Int(noise_reduction+0.5))")
+    
+    // adapt output filename with exposure control setting
+    let suffix_exposure_control_dict = [
+        "Off"             : "",
+        "LinearFullRange" : "_l0",
+        "Linear1EV"       : "_l1",
+        "Curve0EV"        : "_nl0",
+        "Curve1EV"        : "_nl1",
+    ]
+    let suffix_exposure_control = suffix_exposure_control_dict[exposure_control]!
+    
+    let out_filename = in_filename + suffix_merging + suffix_exposure_control + ".dng"
     let out_path = (dng_converter_present ? tmp_dir : out_dir) + out_filename
     var out_url = URL(fileURLWithPath: out_path)
     

--- a/burstphoto/cli.swift
+++ b/burstphoto/cli.swift
@@ -41,9 +41,11 @@ struct MyProgram {
             let search_distance = "Medium"
             // options: "Off", "LinearFullRange", "Linear1EV", "Curve0EV" or "Curve1EV"
             let exposure_control = "LinearFullRange"
+            // options: "Native" or "16Bit"
+            let output_bit_depth = "Native"
             
             // align+merge
-            let out_url = try perform_denoising(image_urls: image_urls, progress: progress, merging_algorithm: merging_algorithm, tile_size: tile_size, search_distance: search_distance, noise_reduction: noise_reduction, exposure_control: exposure_control)
+            let out_url = try perform_denoising(image_urls: image_urls, progress: progress, merging_algorithm: merging_algorithm, tile_size: tile_size, search_distance: search_distance, noise_reduction: noise_reduction, exposure_control: exposure_control, output_bit_depth: output_bit_depth)
            
             print("Image saved in:", out_url.relativePath)            
         }

--- a/burstphoto/dng_utils/dng_sdk_wrapper.cpp
+++ b/burstphoto/dng_utils/dng_sdk_wrapper.cpp
@@ -126,7 +126,7 @@ int read_image(const char* in_path, void** pixel_bytes_pointer, int* width, int*
     return 0;
 }
 
-int write_image(const char *in_path, const char *out_path, void** pixel_bytes_pointer) {
+int write_image(const char *in_path, const char *out_path, void** pixel_bytes_pointer, const int white_level) {
     
     try {
         
@@ -175,7 +175,11 @@ int write_image(const char *in_path, const char *out_path, void** pixel_bytes_po
         //   a difference for other files
         // - this is used in the dng_validate script
         negative->SynchronizeMetadata();
-                   
+            
+        if (white_level > 0) {
+            negative->SetWhiteLevel(white_level);
+        }
+        
         // write dng
         host.SetSaveLinearDNG(false);
         host.SetKeepOriginalFile(false);

--- a/burstphoto/dng_utils/dng_sdk_wrapper.cpp
+++ b/burstphoto/dng_utils/dng_sdk_wrapper.cpp
@@ -177,7 +177,7 @@ int write_image(const char *in_path, const char *out_path, void** pixel_bytes_po
         negative->SynchronizeMetadata();
             
         if (white_level > 0) {
-            negative->SetWhiteLevel(white_level);
+            negative->SetWhiteLevel(white_level, 0);
         }
         
         // write dng

--- a/burstphoto/dng_utils/dng_sdk_wrapper.cpp
+++ b/burstphoto/dng_utils/dng_sdk_wrapper.cpp
@@ -20,7 +20,7 @@ void terminate_xmp_sdk() {
 }
 
 
-int read_image(const char* in_path, void** pixel_bytes_pointer, int* width, int* height, int* mosaic_pattern_width, int* white_level, int* black_level0, int* black_level1, int* black_level2, int* black_level3, int* exposure_bias, float* color_factor_r, float* color_factor_g, float* color_factor_b) {
+int read_image(const char* in_path, void** pixel_bytes_pointer, int* width, int* height, int* mosaic_pattern_width, int* white_level, int* black_level0, int* black_level1, int* black_level2, int* black_level3, int* exposure_bias, float* ISO_exposure_time, float* color_factor_r, float* color_factor_g, float* color_factor_b) {
     
     try {
         
@@ -107,16 +107,21 @@ int read_image(const char* in_path, void** pixel_bytes_pointer, int* width, int*
             }
         }
         
-        // get exposure bias for exposure correction
+        // get exposure bias for exposure correction and product of ISO value and exposure time for control of hot pixel correction
         const dng_exif* exif = negative->GetExif();
         if (exif == NULL) {
             *exposure_bias = -1;
             printf("ERROR: Exif is null.\n");
             return 1;
         } else {
-            dng_srational exposure_bias_value = exif->fExposureBiasValue;
+            const dng_srational exposure_bias_value = exif->fExposureBiasValue;
             // scale exposure bias value that it is EV * 100
-            *exposure_bias = exposure_bias_value.n * 100/exposure_bias_value.d;            
+            *exposure_bias = exposure_bias_value.n * 100/exposure_bias_value.d;
+            
+            const dng_urational exposure_time_value = exif->fExposureTime;
+            const uint32 ISO_speed_value = exif->fISOSpeedRatings[0];
+            // calculate product of ISO value and exposure time
+            *ISO_exposure_time = ISO_speed_value*exposure_time_value.n/float(exposure_time_value.d);
         }
         
     }

--- a/burstphoto/dng_utils/dng_sdk_wrapper.h
+++ b/burstphoto/dng_utils/dng_sdk_wrapper.h
@@ -15,7 +15,7 @@ extern "C" {
     int read_image(const char* in_path, void** pixel_bytes_pointer, int* width, int* height, int* mosaic_pattern_width, int* white_level, int* black_level0, int* black_level1, int* black_level2, int* black_level3, int* exposure_bias, float* color_factor_r, float* color_factor_g, float* color_factor_b);
 
     // function to read a dng image, overwrite its pixel values, and save the result
-    int write_image(const char *in_path, const char *out_path, void** pixel_bytes_pointer);
+    int write_image(const char *in_path, const char *out_path, void** pixel_bytes_pointer, const int white_level);
 
 #ifdef __cplusplus
 }

--- a/burstphoto/dng_utils/dng_sdk_wrapper.h
+++ b/burstphoto/dng_utils/dng_sdk_wrapper.h
@@ -12,7 +12,7 @@ extern "C" {
     void terminate_xmp_sdk();
 
     // function to read a dng image and store its pixel values
-    int read_image(const char* in_path, void** pixel_bytes_pointer, int* width, int* height, int* mosaic_pattern_width, int* white_level, int* black_level0, int* black_level1, int* black_level2, int* black_level3, int* exposure_bias, float* color_factor_r, float* color_factor_g, float* color_factor_b);
+    int read_image(const char* in_path, void** pixel_bytes_pointer, int* width, int* height, int* mosaic_pattern_width, int* white_level, int* black_level0, int* black_level1, int* black_level2, int* black_level3, int* exposure_bias, float* ISO_exposure_time, float* color_factor_r, float* color_factor_g, float* color_factor_b);
 
     // function to read a dng image, overwrite its pixel values, and save the result
     int write_image(const char *in_path, const char *out_path, void** pixel_bytes_pointer, const int white_level);

--- a/burstphoto/dng_utils/dng_sdk_wrapper.swift
+++ b/burstphoto/dng_utils/dng_sdk_wrapper.swift
@@ -59,7 +59,7 @@ func image_url_to_texture(_ url: URL, _ device: MTLDevice) throws -> (MTLTexture
 }
 
 
-func texture_to_dng(_ texture: MTLTexture, _ in_url: URL, _ out_url: URL) throws {
+func texture_to_dng(_ texture: MTLTexture, _ in_url: URL, _ out_url: URL, _ white_level: Int32) throws {
     // synchronize GPU and CPU memory
     let command_buffer = command_queue.makeCommandBuffer()!
     let blit_encoder = command_buffer.makeBlitCommandEncoder()!
@@ -78,7 +78,7 @@ func texture_to_dng(_ texture: MTLTexture, _ in_url: URL, _ out_url: URL) throws
     texture.getBytes(bytes_pointer!, bytesPerRow: bytes_per_row, from: mtl_region, mipmapLevel: 0)
 
     // save image
-    let error_code = write_image(in_url.path, out_url.path, &bytes_pointer)
+    let error_code = write_image(in_url.path, out_url.path, &bytes_pointer, white_level)
     if (error_code != 0) {throw ImageIOError.save_error}
     
     // free memory

--- a/burstphoto/dng_utils/dng_sdk_wrapper.swift
+++ b/burstphoto/dng_utils/dng_sdk_wrapper.swift
@@ -10,7 +10,7 @@ enum ImageIOError: Error {
 
 
 
-func image_url_to_texture(_ url: URL, _ device: MTLDevice) throws -> (MTLTexture, Int, Int, [Int], Int, [Double]) {
+func image_url_to_texture(_ url: URL, _ device: MTLDevice) throws -> (MTLTexture, Int, Int, [Int], Int, Double, [Double]) {
     
     // read image
     var error_code: Int32
@@ -25,12 +25,13 @@ func image_url_to_texture(_ url: URL, _ device: MTLDevice) throws -> (MTLTexture
     var black_level3: Int32 = 0;
     var black_level: [Int] = [0, 0, 0, 0];
     var exposure_bias: Int32 = 0;
+    var ISO_exposure_time: Float32 = 0.0;
     var color_factor_r: Float32 = 0.0;
     var color_factor_g: Float32 = 0.0;
     var color_factor_b: Float32 = 0.0;
     var color_factors: [Double] = [0.0, 0.0, 0.0, 0.0];
     
-    error_code = read_image(url.path, &pixel_bytes, &width, &height, &mosaic_pattern_width, &white_level, &black_level0, &black_level1, &black_level2, &black_level3, &exposure_bias, &color_factor_r, &color_factor_g, &color_factor_b)
+    error_code = read_image(url.path, &pixel_bytes, &width, &height, &mosaic_pattern_width, &white_level, &black_level0, &black_level1, &black_level2, &black_level3, &exposure_bias, &ISO_exposure_time, &color_factor_r, &color_factor_g, &color_factor_b)
     if (error_code != 0) {throw ImageIOError.load_error}
     
     // convert image bitmap to MTLTexture
@@ -55,7 +56,7 @@ func image_url_to_texture(_ url: URL, _ device: MTLDevice) throws -> (MTLTexture
     color_factors[1] = Double(color_factor_g)
     color_factors[2] = Double(color_factor_b)
     
-    return (texture, Int(mosaic_pattern_width), Int(white_level), black_level, Int(exposure_bias), color_factors)
+    return (texture, Int(mosaic_pattern_width), Int(white_level), black_level, Int(exposure_bias), Double(ISO_exposure_time), color_factors)
 }
 
 

--- a/burstphoto/utils.swift
+++ b/burstphoto/utils.swift
@@ -18,7 +18,7 @@ func optionally_convert_dir_to_urls(_ urls: [URL]) -> [URL] {
     return urls
 }
 
-func load_images(_ urls: [URL]) throws -> ([MTLTexture], Int, [Int], [Int], [Int], [Double]) {
+func load_images(_ urls: [URL]) throws -> ([MTLTexture], Int, [Int], [Int], [Int], [Double], [Double]) {
     
     var textures_dict: [Int: MTLTexture] = [:]
     let compute_group = DispatchGroup()
@@ -28,13 +28,14 @@ func load_images(_ urls: [URL]) throws -> ([MTLTexture], Int, [Int], [Int], [Int
     var white_level = Array(repeating: 0, count: urls.count)
     var black_level = Array(repeating: 0, count: 4*urls.count)
     var exposure_bias = Array(repeating: 0, count: urls.count)
+    var ISO_exposure_time = Array(repeating: 0.0, count: urls.count)
     var color_factors = Array(repeating: 0.0, count: 3*urls.count)
 
     for i in 0..<urls.count {
         compute_queue.async(group: compute_group) {
     
             // asynchronously load texture
-            if let (texture, _mosaic_pattern_width, _white_level, _black_level, _exposure_bias, _color_factors) = try? image_url_to_texture(urls[i], device) {
+            if let (texture, _mosaic_pattern_width, _white_level, _black_level, _exposure_bias, _ISO_exposure_time, _color_factors) = try? image_url_to_texture(urls[i], device) {
         
                 // thread-safely save the texture
                 access_queue.sync {
@@ -46,6 +47,7 @@ func load_images(_ urls: [URL]) throws -> ([MTLTexture], Int, [Int], [Int], [Int
                     black_level[4*i+2] = _black_level[2]
                     black_level[4*i+3] = _black_level[3]                    
                     exposure_bias[i] = _exposure_bias
+                    ISO_exposure_time[i] = _ISO_exposure_time
                     color_factors[3*i+0] = _color_factors[0]
                     color_factors[3*i+1] = _color_factors[1]
                     color_factors[3*i+2] = _color_factors[2]
@@ -73,7 +75,7 @@ func load_images(_ urls: [URL]) throws -> ([MTLTexture], Int, [Int], [Int], [Int
         }
     }
     
-    return (textures_list, mosaic_pattern_width!, white_level, black_level, exposure_bias, color_factors)
+    return (textures_list, mosaic_pattern_width!, white_level, black_level, exposure_bias, ISO_exposure_time, color_factors)
 }
 
 // https://stackoverflow.com/questions/26971240/how-do-i-run-a-terminal-command-in-a-swift-script-e-g-xcodebuild


### PR DESCRIPTION
closes #19 

**New features for bursts with Bayer pattern**
- Added optional output with full 16-bit precision. RAWs of most cameras have a bit-depth of 12/14 bits while merging is performed with a bit depth of 32 bit. As a consequence, tonality of the deep shadows is much improved after merging. To preserve this improved tonality, the precision of the output DNG can be increased from 12/14 bits to 16 bits. This feature can considerably reduce quantization errors in the deep shadows and it works for most combinations of camera and RAW processing software. The screenshot below shows an example.
- Improved hot pixel suppression: Hot pixel suppression is deactivated for bursts, where hot pixels are very unlikely, in particular when ISO values are low and shutter speed is fast. After a certain threshold, the strength of the correction is gradually increased until the original strength is reached.

**General improvements**
- Revised layout of settings panel with two tabs view as the number of settings has grown.
- Bug fix: when input frames had inconsistent resolution, the error message was not shown and images were falsely processed
- Bug fix: for some cameras, non-linear exposure correction function did not work correctly due to a division by zero
- Several other small fixes 

It is recommended to inspect the example at 100% zoom level. Shadows lifted by approx. 5 EV.

![Bildschirmfoto 2023-07-30 um 22 18 20](https://github.com/martin-marek/hdr-plus-swift/assets/117006531/21ac5fd2-4d45-43c0-abd9-6f16084206ac)



