### PR TITLE
Fix of magenta cast in highlights for bursts with bracketed exposure

### DIFF
--- a/burstphoto/denoise.swift
+++ b/burstphoto/denoise.swift
@@ -198,7 +198,7 @@ func perform_denoising(image_urls: [URL], progress: ProcessingProgress, merging_
     } else if merging_algorithm == "Higher quality" {
         print("Merging in the frequency domain...")
         
-        try align_merge_frequency_domain(progress: progress, ref_idx: ref_idx, mosaic_pattern_width: mosaic_pattern_width, search_distance: search_distance_int, tile_size: tile_size_int, noise_reduction: noise_reduction, uniform_exposure: uniform_exposure, exposure_bias: exposure_bias, black_level: black_level, color_factors: color_factors, textures: textures, final_texture: final_texture)
+        try align_merge_frequency_domain(progress: progress, ref_idx: ref_idx, mosaic_pattern_width: mosaic_pattern_width, search_distance: search_distance_int, tile_size: tile_size_int, noise_reduction: noise_reduction, uniform_exposure: uniform_exposure, exposure_bias: exposure_bias, white_level: white_level[ref_idx], black_level: black_level, color_factors: color_factors, textures: textures, final_texture: final_texture)
         
     // alignment and merging of tiles in the spatial domain (supports non-Bayer sensors)
     } else {

--- a/burstphoto/merge/frequency.metal
+++ b/burstphoto/merge/frequency.metal
@@ -15,6 +15,7 @@ kernel void merge_frequency_domain(texture2d<float, access::read> ref_texture_ft
                                    texture2d<float, access::read_write> out_texture_ft [[texture(2)]],
                                    texture2d<float, access::read> rms_texture [[texture(3)]],
                                    texture2d<float, access::read> mismatch_texture [[texture(4)]],
+                                   texture2d<float, access::read> highlights_corr_texture [[texture(5)]],
                                    constant float& robustness_norm [[buffer(0)]],
                                    constant float& read_noise [[buffer(1)]],
                                    constant float& max_motion_norm [[buffer(2)]],
@@ -33,6 +34,9 @@ kernel void merge_frequency_domain(texture2d<float, access::read> ref_texture_ft
     float const mismatch_weight = clamp(1.0f - 10.0f*(mismatch-0.2f), 0.0f, 1.0f);
     
     float const motion_norm = clamp(max_motion_norm-(mismatch-0.02f)*(max_motion_norm-1.0f)/0.15f, 1.0f, max_motion_norm);
+    
+    // extract correction factor for clipped highlights
+    float const highlights_norm = highlights_corr_texture.read(gid).r;
     
     // compute tile positions from gid
     int const m0 = gid.x*tile_size;
@@ -142,7 +146,7 @@ kernel void merge_frequency_domain(texture2d<float, access::read> ref_texture_ft
                 // calculate ratio of magnitudes
                 ratio_mag = (alignedMag2[0]+alignedMag2[1]+alignedMag2[2]+alignedMag2[3])/(refMag[0]+refMag[1]+refMag[2]+refMag[3]);
                      
-                // calculate additional normalization factor that increases the merging weight larger magnitudes and decreases weight for lower magnitudes
+                // calculate additional normalization factor that increases the merging weight for larger magnitudes and decreases weight for lower magnitudes
                 magnitude_norm = mismatch_weight*clamp(ratio_mag*ratio_mag*ratio_mag*ratio_mag, 0.5f, 3.0f);
             }
             
@@ -152,7 +156,7 @@ kernel void merge_frequency_domain(texture2d<float, access::read> ref_texture_ft
             // magnitude_norm is based on ideas from [Delbracio 2015]
             
             weight4 = (refRe-alignedRe2)*(refRe-alignedRe2) + (refIm-alignedIm2)*(refIm-alignedIm2);
-            weight4 = weight4/(weight4 + magnitude_norm*motion_norm*noise_norm);
+            weight4 = weight4/(weight4 + magnitude_norm*motion_norm*noise_norm*highlights_norm);
             
             // use the same weight for all color channels to reduce color artifacts as described in [Liba 2019]
             //weight = clamp(max(weight4[0], max(weight4[1], max(weight4[2], weight4[3]))), 0.0f, 1.0f);
@@ -260,6 +264,46 @@ kernel void calculate_rms_rgba(texture2d<float, access::read> ref_texture [[text
     noise_est = 0.25f*sqrt(noise_est)/float(tile_size);
     
     rms_texture.write(noise_est, gid);
+}
+
+
+kernel void check_clipped_highlights_rgba(texture2d<float, access::read> aligned_texture [[texture(0)]],
+                                          texture2d<float, access::write> highlights_corr_texture [[texture(1)]],
+                                          constant int& tile_size [[buffer(0)]],
+                                          constant float& exposure_factor [[buffer(1)]],
+                                          constant float& white_level [[buffer(2)]],
+                                          constant float& black_level_mean [[buffer(3)]],
+                                          uint2 gid [[thread_position_in_grid]]) {
+        
+    float clipped_highlights_corr = 1.0f;
+    
+    if (exposure_factor > 1.001f) {
+        // compute tile positions from gid
+        int const x0 = gid.x*tile_size;
+        int const y0 = gid.y*tile_size;
+        
+        float pixel_value_max;
+        clipped_highlights_corr = 0.0f;
+        
+        // use tile size merge here
+        for (int dy = 0; dy < tile_size; dy++) {
+            for (int dx = 0; dx < tile_size; dx++) {
+          
+                float4 const pixel_value4 = aligned_texture.read(uint2(x0+dx, y0+dy));
+                
+                pixel_value_max = max(pixel_value4[0], max(pixel_value4[1], max(pixel_value4[2], pixel_value4[3])));
+                pixel_value_max = (pixel_value_max-black_level_mean)*exposure_factor + black_level_mean;
+          
+                // ensure smooth transition of contribution of pixel values between 0.50 and 0.99 of the white level
+                clipped_highlights_corr += clamp((pixel_value_max/white_level-0.50f)/0.49f, 0.0f, 1.0f);
+            }
+        }
+
+        clipped_highlights_corr = clipped_highlights_corr/float(tile_size*tile_size);
+        clipped_highlights_corr = clamp((1.0f-clipped_highlights_corr)*(1.0f-clipped_highlights_corr), 0.04f/min(exposure_factor, 4.0f), 1.0f);
+    }
+    
+    highlights_corr_texture.write(clipped_highlights_corr, gid);
 }
 
 

--- a/burstphoto/merge/frequency.metal
+++ b/burstphoto/merge/frequency.metal
@@ -15,7 +15,7 @@ kernel void merge_frequency_domain(texture2d<float, access::read> ref_texture_ft
                                    texture2d<float, access::read_write> out_texture_ft [[texture(2)]],
                                    texture2d<float, access::read> rms_texture [[texture(3)]],
                                    texture2d<float, access::read> mismatch_texture [[texture(4)]],
-                                   texture2d<float, access::read> highlights_corr_texture [[texture(5)]],
+                                   texture2d<float, access::read> highlights_norm_texture [[texture(5)]],
                                    constant float& robustness_norm [[buffer(0)]],
                                    constant float& read_noise [[buffer(1)]],
                                    constant float& max_motion_norm [[buffer(2)]],
@@ -36,7 +36,7 @@ kernel void merge_frequency_domain(texture2d<float, access::read> ref_texture_ft
     float const motion_norm = clamp(max_motion_norm-(mismatch-0.02f)*(max_motion_norm-1.0f)/0.15f, 1.0f, max_motion_norm);
     
     // extract correction factor for clipped highlights
-    float const highlights_norm = highlights_corr_texture.read(gid).r;
+    float const highlights_norm = highlights_norm_texture.read(gid).r;
     
     // compute tile positions from gid
     int const m0 = gid.x*tile_size;
@@ -176,6 +176,49 @@ kernel void merge_frequency_domain(texture2d<float, access::read> ref_texture_ft
 }
 
 
+kernel void calculate_highlights_norm_rgba(texture2d<float, access::read> aligned_texture [[texture(0)]],
+                                           texture2d<float, access::write> highlights_norm_texture [[texture(1)]],
+                                           constant int& tile_size [[buffer(0)]],
+                                           constant float& exposure_factor [[buffer(1)]],
+                                           constant float& white_level [[buffer(2)]],
+                                           constant float& black_level_mean [[buffer(3)]],
+                                           uint2 gid [[thread_position_in_grid]]) {
+    
+    // set to 1.0, which does not apply any correction
+    float clipped_highlights_norm = 1.0f;
+    
+    // if the frame has no uniform exposure
+    if (exposure_factor > 1.001f) {
+        // compute tile positions from gid
+        int const x0 = gid.x*tile_size;
+        int const y0 = gid.y*tile_size;
+        
+        float pixel_value_max;
+        clipped_highlights_norm = 0.0f;
+        
+        // calculate fraction of highlight pixels brighter than 0.5 of white level
+        for (int dy = 0; dy < tile_size; dy++) {
+            for (int dx = 0; dx < tile_size; dx++) {
+          
+                float4 const pixel_value4 = aligned_texture.read(uint2(x0+dx, y0+dy));
+                
+                pixel_value_max = max(pixel_value4[0], max(pixel_value4[1], max(pixel_value4[2], pixel_value4[3])));
+                pixel_value_max = (pixel_value_max-black_level_mean)*exposure_factor + black_level_mean;
+          
+                // ensure smooth transition of contribution of pixel values between 0.50 and 0.99 of the white level
+                clipped_highlights_norm += clamp((pixel_value_max/white_level-0.50f)/0.49f, 0.0f, 1.0f);
+            }
+        }
+
+        clipped_highlights_norm = clipped_highlights_norm/float(tile_size*tile_size);
+        // transform into a correction for the merging formula
+        clipped_highlights_norm = clamp((1.0f-clipped_highlights_norm)*(1.0f-clipped_highlights_norm), 0.04f/min(exposure_factor, 4.0f), 1.0f);
+    }
+    
+    highlights_norm_texture.write(clipped_highlights_norm, gid);
+}
+
+
 kernel void calculate_mismatch_rgba(texture2d<float, access::read> ref_texture [[texture(0)]],
                                     texture2d<float, access::read> aligned_texture [[texture(1)]],
                                     texture2d<float, access::read> rms_texture [[texture(2)]],
@@ -264,46 +307,6 @@ kernel void calculate_rms_rgba(texture2d<float, access::read> ref_texture [[text
     noise_est = 0.25f*sqrt(noise_est)/float(tile_size);
     
     rms_texture.write(noise_est, gid);
-}
-
-
-kernel void check_clipped_highlights_rgba(texture2d<float, access::read> aligned_texture [[texture(0)]],
-                                          texture2d<float, access::write> highlights_corr_texture [[texture(1)]],
-                                          constant int& tile_size [[buffer(0)]],
-                                          constant float& exposure_factor [[buffer(1)]],
-                                          constant float& white_level [[buffer(2)]],
-                                          constant float& black_level_mean [[buffer(3)]],
-                                          uint2 gid [[thread_position_in_grid]]) {
-        
-    float clipped_highlights_corr = 1.0f;
-    
-    if (exposure_factor > 1.001f) {
-        // compute tile positions from gid
-        int const x0 = gid.x*tile_size;
-        int const y0 = gid.y*tile_size;
-        
-        float pixel_value_max;
-        clipped_highlights_corr = 0.0f;
-        
-        // use tile size merge here
-        for (int dy = 0; dy < tile_size; dy++) {
-            for (int dx = 0; dx < tile_size; dx++) {
-          
-                float4 const pixel_value4 = aligned_texture.read(uint2(x0+dx, y0+dy));
-                
-                pixel_value_max = max(pixel_value4[0], max(pixel_value4[1], max(pixel_value4[2], pixel_value4[3])));
-                pixel_value_max = (pixel_value_max-black_level_mean)*exposure_factor + black_level_mean;
-          
-                // ensure smooth transition of contribution of pixel values between 0.50 and 0.99 of the white level
-                clipped_highlights_corr += clamp((pixel_value_max/white_level-0.50f)/0.49f, 0.0f, 1.0f);
-            }
-        }
-
-        clipped_highlights_corr = clipped_highlights_corr/float(tile_size*tile_size);
-        clipped_highlights_corr = clamp((1.0f-clipped_highlights_corr)*(1.0f-clipped_highlights_corr), 0.04f/min(exposure_factor, 4.0f), 1.0f);
-    }
-    
-    highlights_corr_texture.write(clipped_highlights_corr, gid);
 }
 
 

--- a/burstphoto/merge/frequency.swift
+++ b/burstphoto/merge/frequency.swift
@@ -7,9 +7,9 @@ import MetalPerformanceShaders
 
 let merge_frequency_domain_state = try! device.makeComputePipelineState(function: mfl.makeFunction(name: "merge_frequency_domain")!)
 
+let calculate_highlights_norm_rgba_state = try! device.makeComputePipelineState(function: mfl.makeFunction(name: "calculate_highlights_norm_rgba")!)
 let calculate_mismatch_rgba_state = try! device.makeComputePipelineState(function: mfl.makeFunction(name: "calculate_mismatch_rgba")!)
 let calculate_rms_rgba_state = try! device.makeComputePipelineState(function: mfl.makeFunction(name: "calculate_rms_rgba")!)
-let check_clipped_highlights_rgba_state = try! device.makeComputePipelineState(function: mfl.makeFunction(name: "check_clipped_highlights_rgba")!)
 let deconvolute_frequency_domain_state = try! device.makeComputePipelineState(function: mfl.makeFunction(name: "deconvolute_frequency_domain")!)
 let normalize_mismatch_state = try! device.makeComputePipelineState(function: mfl.makeFunction(name: "normalize_mismatch")!)
 let reduce_artifacts_tile_border_state = try! device.makeComputePipelineState(function: mfl.makeFunction(name: "reduce_artifacts_tile_border")!)
@@ -43,7 +43,7 @@ func align_merge_frequency_domain(progress: ProcessingProgress, ref_idx: Int, mo
     exposure_corr2 /= Double(exposure_bias.count)
             
     // derive normalized robustness value: two steps in noise_reduction (-2.0 in this case) yield an increase by a factor of two in the robustness norm with the idea that the variance of shot noise increases by a factor of two per iso level
-    let robustness_rev = 0.5*(26.5-Double(Int(noise_reduction+0.5)))
+    let robustness_rev = 0.5*((uniform_exposure ? 26.5 : 28.5) - Double(Int(noise_reduction+0.5)))
     let robustness_norm = exposure_corr1/exposure_corr2*pow(2.0, (-robustness_rev + 7.5))
     
     // derive estimate of read noise with the idea that read noise increases approx. by a factor of three (stronger than increase in shot noise) per iso level to increase noise reduction in darker regions relative to bright regions
@@ -186,7 +186,7 @@ func align_merge_frequency_domain(progress: ProcessingProgress, ref_idx: Int, mo
             // add mismatch texture to the total, accumulated mismatch texture
             add_texture(mismatch_texture, total_mismatch_texture, textures.count)
          
-            let highlights_corr_texture = check_clipped_highlights_rgba(aligned_texture_rgba, exposure_factor, tile_info_merge, (white_level == -1 ? 1000000 : white_level), black_level_mean)
+            let highlights_norm_texture = calculate_highlights_norm_rgba(aligned_texture_rgba, exposure_factor, tile_info_merge, (white_level == -1 ? 1000000 : white_level), black_level_mean)
             
             // start debug capture
             //let capture_manager = MTLCaptureManager.shared()
@@ -201,7 +201,7 @@ func align_merge_frequency_domain(progress: ProcessingProgress, ref_idx: Int, mo
             let max_motion_norm_exposure = (uniform_exposure ? max_motion_norm : min(4.0, exposure_factor)*sqrt(max_motion_norm))
             
             // merge aligned comparison texture with reference texture in the frequency domain
-            merge_frequency_domain(ref_texture_ft, aligned_texture_ft, final_texture_ft, rms_texture, mismatch_texture, highlights_corr_texture, robustness_norm, read_noise, max_motion_norm_exposure, uniform_exposure, tile_info_merge)
+            merge_frequency_domain(ref_texture_ft, aligned_texture_ft, final_texture_ft, rms_texture, mismatch_texture, highlights_norm_texture, robustness_norm, read_noise, max_motion_norm_exposure, uniform_exposure, tile_info_merge)
             
             // stop debug capture
             //capture_manager.stopCapture()
@@ -224,6 +224,33 @@ func align_merge_frequency_domain(progress: ProcessingProgress, ref_idx: Int, mo
         
         print("Align+merge (\(i)/4): ", Float(DispatchTime.now().uptimeNanoseconds - t0) / 1_000_000_000)
     }
+}
+
+
+func calculate_highlights_norm_rgba(_ aligned_texture: MTLTexture, _ exposure_factor: Double, _ tile_info: TileInfo, _ white_level: Int, _ black_level_mean: Double) -> MTLTexture {
+  
+    // create mismatch texture
+    let highlights_norm_texture_descriptor = MTLTextureDescriptor.texture2DDescriptor(pixelFormat: .r32Float, width: tile_info.n_tiles_x, height: tile_info.n_tiles_y, mipmapped: false)
+    highlights_norm_texture_descriptor.usage = [.shaderRead, .shaderWrite]
+    let highlights_norm_texture = device.makeTexture(descriptor: highlights_norm_texture_descriptor)!
+    
+    let command_buffer = command_queue.makeCommandBuffer()!
+    let command_encoder = command_buffer.makeComputeCommandEncoder()!
+    let state = calculate_highlights_norm_rgba_state
+    command_encoder.setComputePipelineState(state)
+    let threads_per_grid = MTLSize(width: tile_info.n_tiles_x, height: tile_info.n_tiles_y, depth: 1)
+    let threads_per_thread_group = get_threads_per_thread_group(state, threads_per_grid)
+    command_encoder.setTexture(aligned_texture, index: 0)
+    command_encoder.setTexture(highlights_norm_texture, index: 1)
+    command_encoder.setBytes([Int32(tile_info.tile_size_merge)], length: MemoryLayout<Int32>.stride, index: 0)
+    command_encoder.setBytes([Float32(exposure_factor)], length: MemoryLayout<Float32>.stride, index: 1)
+    command_encoder.setBytes([Float32(white_level)], length: MemoryLayout<Float32>.stride, index: 2)
+    command_encoder.setBytes([Float32(black_level_mean)], length: MemoryLayout<Float32>.stride, index: 3)
+    command_encoder.dispatchThreads(threads_per_grid, threadsPerThreadgroup: threads_per_thread_group)
+    command_encoder.endEncoding()
+    command_buffer.commit()
+    
+    return highlights_norm_texture
 }
 
 
@@ -274,33 +301,6 @@ func calculate_rms_rgba(_ in_texture: MTLTexture, _ tile_info: TileInfo) -> MTLT
     command_buffer.commit()
     
     return rms_texture
-}
-
-
-func check_clipped_highlights_rgba(_ aligned_texture: MTLTexture, _ exposure_factor: Double, _ tile_info: TileInfo, _ white_level: Int, _ black_level_mean: Double) -> MTLTexture {
-  
-    // create mismatch texture
-    let highlights_corr_texture_descriptor = MTLTextureDescriptor.texture2DDescriptor(pixelFormat: .r32Float, width: tile_info.n_tiles_x, height: tile_info.n_tiles_y, mipmapped: false)
-    highlights_corr_texture_descriptor.usage = [.shaderRead, .shaderWrite]
-    let highlights_corr_texture = device.makeTexture(descriptor: highlights_corr_texture_descriptor)!
-    
-    let command_buffer = command_queue.makeCommandBuffer()!
-    let command_encoder = command_buffer.makeComputeCommandEncoder()!
-    let state = check_clipped_highlights_rgba_state
-    command_encoder.setComputePipelineState(state)
-    let threads_per_grid = MTLSize(width: tile_info.n_tiles_x, height: tile_info.n_tiles_y, depth: 1)
-    let threads_per_thread_group = get_threads_per_thread_group(state, threads_per_grid)
-    command_encoder.setTexture(aligned_texture, index: 0)
-    command_encoder.setTexture(highlights_corr_texture, index: 1)
-    command_encoder.setBytes([Int32(tile_info.tile_size_merge)], length: MemoryLayout<Int32>.stride, index: 0)
-    command_encoder.setBytes([Float32(exposure_factor)], length: MemoryLayout<Float32>.stride, index: 1)
-    command_encoder.setBytes([Float32(white_level)], length: MemoryLayout<Float32>.stride, index: 2)
-    command_encoder.setBytes([Float32(black_level_mean)], length: MemoryLayout<Float32>.stride, index: 3)    
-    command_encoder.dispatchThreads(threads_per_grid, threadsPerThreadgroup: threads_per_thread_group)
-    command_encoder.endEncoding()
-    command_buffer.commit()
-    
-    return highlights_corr_texture
 }
 
 
@@ -366,7 +366,7 @@ func forward_ft(_ in_texture: MTLTexture, _ out_texture_ft: MTLTexture, _ tmp_te
 }
 
 
-func merge_frequency_domain(_ ref_texture_ft: MTLTexture, _ aligned_texture_ft: MTLTexture, _ out_texture_ft: MTLTexture, _ rms_texture: MTLTexture, _ mismatch_texture: MTLTexture, _ highlights_corr_texture: MTLTexture, _ robustness_norm: Double, _ read_noise: Double, _ max_motion_norm: Double, _ uniform_exposure: Bool, _ tile_info: TileInfo) {
+func merge_frequency_domain(_ ref_texture_ft: MTLTexture, _ aligned_texture_ft: MTLTexture, _ out_texture_ft: MTLTexture, _ rms_texture: MTLTexture, _ mismatch_texture: MTLTexture, _ highlights_norm_texture: MTLTexture, _ robustness_norm: Double, _ read_noise: Double, _ max_motion_norm: Double, _ uniform_exposure: Bool, _ tile_info: TileInfo) {
         
     let command_buffer = command_queue.makeCommandBuffer()!
     let command_encoder = command_buffer.makeComputeCommandEncoder()!
@@ -379,7 +379,7 @@ func merge_frequency_domain(_ ref_texture_ft: MTLTexture, _ aligned_texture_ft: 
     command_encoder.setTexture(out_texture_ft, index: 2)
     command_encoder.setTexture(rms_texture, index: 3)
     command_encoder.setTexture(mismatch_texture, index: 4)
-    command_encoder.setTexture(highlights_corr_texture, index: 5)
+    command_encoder.setTexture(highlights_norm_texture, index: 5)
     command_encoder.setBytes([Float32(robustness_norm)], length: MemoryLayout<Float32>.stride, index: 0)
     command_encoder.setBytes([Float32(read_noise)], length: MemoryLayout<Float32>.stride, index: 1)
     command_encoder.setBytes([Float32(max_motion_norm)], length: MemoryLayout<Float32>.stride, index: 2)


### PR DESCRIPTION
closes #29 

As suggested, a new tile-specific factor was introduced that strongly decreases the weight of a tile in the merging process if it contains clipped pixels (for exposure bracketed bursts only). In addition, the strength of noise reduction was slightly decreased for any exposure bracketed bursts as these bursts are more vulnerable to merging artifacts.