### PR TITLE
Expanded X-Trans Support

### DIFF
--- a/burstphoto/denoise.swift
+++ b/burstphoto/denoise.swift
@@ -224,9 +224,7 @@ func perform_denoising(image_urls: [URL], progress: ProcessingProgress, merging_
         last_settings = current_settings
     }
     
-    if (mosaic_pattern_width == 2 && exposure_control != "Off") {
-        correct_exposure(final_texture, white_level[ref_idx], black_level, exposure_control, exposure_bias, uniform_exposure, color_factors, ref_idx)
-    }
+    correct_exposure(final_texture, white_level[ref_idx], black_level, exposure_control, exposure_bias, uniform_exposure, color_factors, mosaic_pattern_width, ref_idx)
     
     // apply scaling to 16 bit
     let scale_to_16bit = (output_bit_depth=="16Bit" && mosaic_pattern_width == 2 && exposure_control != "Off")

--- a/burstphoto/denoise.swift
+++ b/burstphoto/denoise.swift
@@ -211,9 +211,7 @@ func perform_denoising(image_urls: [URL], progress: ProcessingProgress, merging_
         fill_with_zeros(final_texture)
         
         correct_hotpixels(textures, black_level, ISO_exposure_time, noise_reduction, mosaic_pattern_width)
-        if mosaic_pattern_width == 2 {
-            equalize_exposure(textures, black_level, exposure_bias, ref_idx)
-        }
+        equalize_exposure(textures, black_level, exposure_bias, ref_idx, mosaic_pattern_width)
         
         if noise_reduction == 23.0 {
             try calculate_temporal_average(progress: progress, mosaic_pattern_width: mosaic_pattern_width, exposure_bias: exposure_bias, white_level: white_level[ref_idx], black_level: black_level, uniform_exposure: uniform_exposure, color_factors: color_factors, textures: textures, final_texture: final_texture)

--- a/burstphoto/denoise.swift
+++ b/burstphoto/denoise.swift
@@ -210,8 +210,8 @@ func perform_denoising(image_urls: [URL], progress: ProcessingProgress, merging_
         final_texture = device.makeTexture(descriptor: final_texture_descriptor)!
         fill_with_zeros(final_texture)
         
+        correct_hotpixels(textures, black_level, ISO_exposure_time, noise_reduction, mosaic_pattern_width)
         if mosaic_pattern_width == 2 {
-            correct_hotpixels(textures, black_level, ISO_exposure_time, noise_reduction)
             equalize_exposure(textures, black_level, exposure_bias, ref_idx)
         }
         

--- a/burstphoto/exposure/exposure.metal
+++ b/burstphoto/exposure/exposure.metal
@@ -109,21 +109,18 @@ kernel void correct_exposure_linear(texture2d<float, access::read_write> final_t
 }
 
 /**
- Exposure correction in case of a burst with exposure bracketing
+ Exposure correction in case of a burst with exposure bracketing for Bayer Sensor
  */
-kernel void equalize_exposure(texture2d<float, access::read_write> comp_texture [[texture(0)]],
-                             constant int& exposure_diff [[buffer(0)]],
-                             constant int& black_level0 [[buffer(1)]],
-                             constant int& black_level1 [[buffer(2)]],
-                             constant int& black_level2 [[buffer(3)]],
-                             constant int& black_level3 [[buffer(4)]],
-                             uint2 gid [[thread_position_in_grid]]) {
-       
+kernel void equalize_exposure_bayer(texture2d<float, access::read_write> comp_texture [[texture(0)]],
+                                    constant int& exposure_diff [[buffer(0)]],
+                                    constant int* black_levels [[buffer(1)]],
+                                    uint2 gid [[thread_position_in_grid]]) {
+
     int const x = gid.x*2;
     int const y = gid.y*2;
     
     // load args
-    float4 const black_level = float4(black_level0, black_level1, black_level2, black_level3);
+    float4 const black_level = float4(black_levels[0], black_levels[1], black_levels[2], black_levels[3]);
     
     // extract pixel values of 2x2 super pixel
     float4 pixel_value = float4(comp_texture.read(uint2(x,   y)).r,
@@ -135,7 +132,9 @@ kernel void equalize_exposure(texture2d<float, access::read_write> comp_texture 
     float const corr_factor = pow(2.0f, float(exposure_diff/100.0f));
     
     // correct exposure
+    // TODO: Is this + black_level necessary?
     pixel_value = (pixel_value - black_level)*corr_factor + black_level;
+    // TODO: I don't think this should clamp to 16-bit for internal calculations, I think it's costing us highlight recovery.
     pixel_value = clamp(pixel_value, 0.0f, float(FLOAT16_MAX_VAL));
 
     // write back into texture
@@ -145,6 +144,29 @@ kernel void equalize_exposure(texture2d<float, access::read_write> comp_texture 
     comp_texture.write(pixel_value[3], uint2(x+1, y+1));
 }
 
+/**
+ Exposure correction in case of a burst with exposure bracketing for X-Trans Sensor
+ TODO: Benchmark against a float3 implementation and see if that's faster
+ */
+kernel void equalize_exposure_xtrans(texture2d<float, access::read_write> comp_texture [[texture(0)]],
+                                     constant int& exposure_diff [[buffer(0)]],
+                                     constant int* black_levels [[buffer(1)]],
+                                     uint2 gid [[thread_position_in_grid]]) {
+    
+    float const black_level = float(black_levels[gid.x % 6 + 6*(gid.y % 6)]);
+       
+    // calculate exposure correction factor from exposure difference
+    float const corr_factor = pow(2.0f, float(exposure_diff/100.0f));
+    
+    // correct exposure
+    // TODO: Is this +black_level necessary?
+    float pixel_value = (comp_texture.read(gid).r - black_level)*corr_factor + black_level;
+    // TODO: I don't think this should clamp to 16-bit for internal calculations, I think it's costing us highlight recovery.
+    pixel_value = clamp(pixel_value, 0.0f, float(FLOAT16_MAX_VAL));
+
+    // write back into texture
+    comp_texture.write(pixel_value, gid);
+}
 
 kernel void max_x(texture1d<float, access::read> in_texture [[texture(0)]],
                   device float *out_buffer [[buffer(0)]],

--- a/burstphoto/exposure/exposure.swift
+++ b/burstphoto/exposure/exposure.swift
@@ -14,48 +14,32 @@ let max_y_state = try! device.makeComputePipelineState(function: mfl.makeFunctio
 /// By lifting the shadows they suffer less from quantization errors, this is especially beneficial as the bit-depth of the image decreases.
 ///
 /// Inspired by https://www-old.cs.utah.edu/docs/techreports/2002/pdf/UUCS-02-001.pdf
-func correct_exposure(_ final_texture: MTLTexture, _ white_level: Int, _ black_level: [[Int]], _ exposure_control: String, _ exposure_bias: [Int], _ uniform_exposure: Bool, _ color_factors: [[Double]], _ ref_idx: Int) {
+func correct_exposure(_ final_texture: MTLTexture, _ white_level: Int, _ black_levels: [[Int]], _ exposure_control: String, _ exposure_bias: [Int], _ uniform_exposure: Bool, _ color_factors: [[Double]], _ mosaic_pattern_width: Int, _ ref_idx: Int) {
               
     // only apply exposure correction if reference image has an exposure, which is lower than the target exposure
-    if (exposure_control != "Off" && white_level != -1 && black_level[0][0] != -1) {
-          
-        var final_texture_blurred = blur(final_texture, with_pattern_width: 2, using_kernel_size: 2)
+    if (exposure_control != "Off" && white_level != -1 && black_levels[0][0] != -1) {
+        var final_texture_blurred = blur(final_texture, with_pattern_width: mosaic_pattern_width, using_kernel_size: 2)
         let max_texture_buffer = texture_max(final_texture_blurred)
         
-        // find index of image with longest exposure to use the most robust black level value
-        var exp_idx = 0
-        for comp_idx in 0..<exposure_bias.count {
-             if (exposure_bias[comp_idx] > exposure_bias[exp_idx]) {
-                exp_idx = comp_idx
-            }
-        }
-        
-        var black_level0 = 0.0
-        var black_level1 = 0.0
-        var black_level2 = 0.0
-        var black_level3 = 0.0
-        
-        // if exposure levels are uniform, calculate mean value of all exposures
-        if uniform_exposure {
-            
+        var black_levels_representative: [Float32] = Array(repeating: 0.0, count: mosaic_pattern_width*mosaic_pattern_width)
+        if uniform_exposure { // if exposure levels are uniform, calculate mean value of all exposures
             for comp_idx in 0..<exposure_bias.count {
-                black_level0 += Double(black_level[comp_idx][0])
-                black_level1 += Double(black_level[comp_idx][1])
-                black_level2 += Double(black_level[comp_idx][2])
-                black_level3 += Double(black_level[comp_idx][3])
+                for i in 0..<black_levels[comp_idx].count {
+                    black_levels_representative[i] += Float32(black_levels[comp_idx][i])
+                }
             }
-            
-            black_level0 /= Double(exposure_bias.count)
-            black_level1 /= Double(exposure_bias.count)
-            black_level2 /= Double(exposure_bias.count)
-            black_level3 /= Double(exposure_bias.count)
-            
-        } else {
-            black_level0 = Double(black_level[exp_idx][0])
-            black_level1 = Double(black_level[exp_idx][1])
-            black_level2 = Double(black_level[exp_idx][2])
-            black_level3 = Double(black_level[exp_idx][3])
+            black_levels_representative = black_levels_representative.map{Float32($0 / Float32(black_levels.count))}
+        } else { // find index of image with longest exposure to use the most robust black level value
+            var exp_idx = 0
+            for comp_idx in 0..<exposure_bias.count {
+                 if (exposure_bias[comp_idx] > exposure_bias[exp_idx]) {
+                    exp_idx = comp_idx
+                }
+            }
+            black_levels_representative = black_levels[exp_idx].map {Float32($0)}
         }
+        let black_levels_buffer = device.makeBuffer(bytes: black_levels_representative,
+                                                    length: MemoryLayout<Float32>.size * black_levels_representative.count)!
         
         let command_buffer = command_queue.makeCommandBuffer()!
         command_buffer.label = "Correct Exposure"
@@ -66,29 +50,37 @@ func correct_exposure(_ final_texture: MTLTexture, _ white_level: Int, _ black_l
         let threads_per_thread_group = get_threads_per_thread_group(state, threads_per_grid)
        
         if (exposure_control=="Curve0EV" || exposure_control=="Curve1EV") {
-            let color_factor_mean = 0.25*(color_factors[ref_idx][0]+2.0*color_factors[ref_idx][1]+color_factors[ref_idx][2])
+            let color_factor_mean: Double
+            if (mosaic_pattern_width == 6) {
+                color_factor_mean = (8.0*color_factors[ref_idx][0] + 20.0*color_factors[ref_idx][1] + 8.0*color_factors[ref_idx][2]) / 36.0
+            } else if (mosaic_pattern_width == 2) {
+                color_factor_mean = (    color_factors[ref_idx][0] +  2.0*color_factors[ref_idx][1] +     color_factors[ref_idx][2]) /  4.0
+            } else {
+                color_factor_mean = (    color_factors[ref_idx][0] +      color_factors[ref_idx][1] +     color_factors[ref_idx][2]) /  3.0
+            }
             final_texture_blurred = blur(final_texture, with_pattern_width: 1, using_kernel_size: 1)
             
             command_encoder.setTexture(final_texture_blurred, index: 0)
-            command_encoder.setTexture(final_texture, index: 1)
-            command_encoder.setBytes([Int32(exposure_bias[ref_idx])], length: MemoryLayout<Int32>.stride, index: 0)
-            command_encoder.setBytes([Int32(exposure_control=="Curve0EV" ? 0 : 100)], length: MemoryLayout<Int32>.stride, index: 1)
-            command_encoder.setBytes([Float32(white_level)], length: MemoryLayout<Float32>.stride, index: 2)
-            command_encoder.setBytes([Float32(black_level0)], length: MemoryLayout<Float32>.stride, index: 3)
-            command_encoder.setBytes([Float32(black_level1)], length: MemoryLayout<Float32>.stride, index: 4)
-            command_encoder.setBytes([Float32(black_level2)], length: MemoryLayout<Float32>.stride, index: 5)
-            command_encoder.setBytes([Float32(black_level3)], length: MemoryLayout<Float32>.stride, index: 6)
-            command_encoder.setBytes([Float32(color_factor_mean)], length: MemoryLayout<Float32>.stride, index: 7)
-            command_encoder.setBuffer(max_texture_buffer, offset: 0, index: 8)
+            command_encoder.setTexture(final_texture,         index: 1)
+            
+            command_encoder.setBytes([Int32(exposure_bias[ref_idx])],                   length: MemoryLayout<Int32>.stride,   index: 0)
+            command_encoder.setBytes([Int32(exposure_control=="Curve0EV" ? 0 : 100)],   length: MemoryLayout<Int32>.stride,   index: 1)
+            command_encoder.setBytes([Int32(mosaic_pattern_width)],                     length: MemoryLayout<Int32>.stride,   index: 2)
+            command_encoder.setBytes([Float32(white_level)],                            length: MemoryLayout<Float32>.stride, index: 3)
+            command_encoder.setBytes([Float32(color_factor_mean)],                      length: MemoryLayout<Float32>.stride, index: 4)
+            
+            command_encoder.setBuffer(black_levels_buffer, offset: 0, index: 5)
+            command_encoder.setBuffer(max_texture_buffer,  offset: 0, index: 6)
         } else {
             command_encoder.setTexture(final_texture, index: 0)
-            command_encoder.setBytes([Float32(white_level)], length: MemoryLayout<Float32>.stride, index: 0)
-            command_encoder.setBytes([Float32(black_level0)], length: MemoryLayout<Float32>.stride, index: 1)
-            command_encoder.setBytes([Float32(black_level1)], length: MemoryLayout<Float32>.stride, index: 2)
-            command_encoder.setBytes([Float32(black_level2)], length: MemoryLayout<Float32>.stride, index: 3)
-            command_encoder.setBytes([Float32(black_level3)], length: MemoryLayout<Float32>.stride, index: 4)
-            command_encoder.setBuffer(max_texture_buffer, offset: 0, index: 5)
-            command_encoder.setBytes([Float32(exposure_control=="LinearFullRange" ? -1.0 : 2.0)], length: MemoryLayout<Float32>.stride, index: 6)
+            
+            command_encoder.setBytes([Int32(mosaic_pattern_width)],                                 length: MemoryLayout<Int32>.stride,   index: 0)
+            command_encoder.setBytes([Float32(white_level)],                                        length: MemoryLayout<Float32>.stride, index: 1)
+            command_encoder.setBytes([Float32(exposure_control=="LinearFullRange" ? -1.0 : 2.0)],   length: MemoryLayout<Float32>.stride, index: 2)
+            
+            command_encoder.setBuffer(black_levels_buffer, offset: 0, index: 3)
+            command_encoder.setBuffer(max_texture_buffer,  offset: 0, index: 4)
+            
         }
         command_encoder.dispatchThreads(threads_per_grid, threadsPerThreadgroup: threads_per_thread_group)
         command_encoder.endEncoding()

--- a/burstphoto/merge/frequency.swift
+++ b/burstphoto/merge/frequency.swift
@@ -180,7 +180,13 @@ func align_merge_frequency_domain(progress: ProcessingProgress, ref_idx: Int, mo
             let mismatch_texture = calculate_mismatch_rgba(aligned_texture_rgba, ref_texture_rgba, rms_texture, exposure_factor, tile_info_merge)
             
             // normalize mismatch texture
-            let mean_mismatch = texture_mean(crop_texture(mismatch_texture, shift_left/tile_size_merge, shift_right/tile_size_merge, shift_top/tile_size_merge, shift_bottom/tile_size_merge), .r)
+            let mean_mismatch = texture_mean(crop_texture(mismatch_texture,
+                                                          shift_left/tile_size_merge,
+                                                          shift_right/tile_size_merge,
+                                                          shift_top/tile_size_merge,
+                                                          shift_bottom/tile_size_merge),
+                                             per_sub_pixel: false,
+                                             mosaic_pattern_width: mosaic_pattern_width)
             normalize_mismatch(mismatch_texture, mean_mismatch)
             
             // add mismatch texture to the total, accumulated mismatch texture

--- a/burstphoto/merge/spatial.swift
+++ b/burstphoto/merge/spatial.swift
@@ -131,7 +131,7 @@ func estimate_color_noise(_ texture: MTLTexture, _ texture_blurred: MTLTexture, 
     let texture_diff = color_difference(between: texture, and: texture_blurred, mosaic_pattern_width: mosaic_pattern_width)
     
     // compute the average of the difference between the original and the blurred texture
-    let mean_diff = texture_mean(texture_diff, .r)
+    let mean_diff = texture_mean(texture_diff, per_sub_pixel: false, mosaic_pattern_width: mosaic_pattern_width)
     
     return mean_diff
 }

--- a/burstphoto/texture/texture.metal
+++ b/burstphoto/texture/texture.metal
@@ -193,73 +193,6 @@ kernel void add_texture_weighted(texture2d<float, access::read> texture1 [[textu
 }
 
 
-kernel void average_x(texture1d<float, access::read> in_texture [[texture(0)]],
-                      device float *out_buffer [[buffer(0)]],
-                      constant int& width [[buffer(1)]],
-                      uint gid [[thread_position_in_grid]]) {
-    float total = 0;
-    
-    for (int x = 0; x < width; x++) {
-        total += in_texture.read(uint(x)).r;
-    }
-    
-    float avg = total / width;
-    out_buffer[0] = avg;
-}
-
-
-kernel void average_y(texture2d<float, access::read> in_texture [[texture(0)]],
-                      texture1d<float, access::write> out_texture [[texture(1)]],
-                      uint gid [[thread_position_in_grid]]) {
-    uint x = gid;
-    int texture_height = in_texture.get_height();
-    float total = 0;
-    
-    for (int y = 0; y < texture_height; y++) {
-        total += in_texture.read(uint2(x, y)).r;
-    }
-    
-    float avg = total / texture_height;
-    out_texture.write(avg, x);
-}
-
-
-kernel void average_x_rgba(texture1d<float, access::read> in_texture [[texture(0)]],
-                           device float *out_buffer [[buffer(0)]],
-                           constant int& width [[buffer(1)]],
-                           uint gid [[thread_position_in_grid]]) {
-    
-    float4 total = float4(0.0f, 0.0f, 0.0f, 0.0f);
-    
-    for (int x = 0; x < width; x++) {
-        total += in_texture.read(uint(x));
-    }
-    
-    float4 avg = total / width;
-    out_buffer[0] = avg[0];
-    out_buffer[1] = avg[1];
-    out_buffer[2] = avg[2];
-    out_buffer[3] = avg[3];
-}
-
-
-kernel void average_y_rgba(texture2d<float, access::read> in_texture [[texture(0)]],
-                           texture1d<float, access::write> out_texture [[texture(1)]],
-                           uint gid [[thread_position_in_grid]]) {
-    uint x = gid;
-    
-    int texture_height = in_texture.get_height();
-    float4 total = float4(0.0f, 0.0f, 0.0f, 0.0f);
-    
-    for (int y = 0; y < texture_height; y++) {
-        total += in_texture.read(uint2(x, y));
-    }
-    
-    float4 avg = total / texture_height;
-    out_texture.write(avg, x);
-}
-
-
 kernel void blur_mosaic_texture(texture2d<float, access::read> in_texture [[texture(0)]],
                                 texture2d<float, access::write> out_texture [[texture(1)]],
                                 constant int& kernel_size [[buffer(0)]],
@@ -596,6 +529,26 @@ kernel void crop_texture(texture2d<float, access::read> in_texture [[texture(0)]
 }
 
 
+kernel void divide_buffer(device   float  *in_buffer   [[buffer(0)]],
+                          device   float  *out_buffer  [[buffer(1)]],
+                          constant float& divisor      [[buffer(2)]],
+                          constant int&   buffer_size  [[buffer(3)]],  // Unused. Here to keep signature consistent with sum_divide_buffer
+                          uint2 gid [[thread_position_in_grid]]) {
+    out_buffer[gid.x] = in_buffer[gid.x] / divisor;
+}
+
+kernel void sum_divide_buffer(device   float  *in_buffer   [[buffer(0)]],
+                              device   float  *out_buffer  [[buffer(1)]],
+                              constant float& divisor      [[buffer(2)]],
+                              constant int&   buffer_size  [[buffer(3)]],
+                              uint2 gid [[thread_position_in_grid]]) {
+    for (int i = 0; i < buffer_size; i++) {
+        out_buffer[0] += in_buffer[i];
+    }
+    out_buffer[0] /= divisor;
+}
+
+
 kernel void extend_texture(texture2d<float, access::read> in_texture [[texture(0)]],
                            texture2d<float, access::write> out_texture [[texture(1)]],
                            constant int& pad_left [[buffer(0)]],
@@ -623,13 +576,32 @@ kernel void normalize_texture(texture2d<float, access::read_write> in_texture [[
 }
 
 
-kernel void sum_rect_columns(texture2d<uint, access::read> in_texture [[texture(0)]],
-                             texture2d<float, access::write> out_texture [[texture(1)]],
-                             constant int& top [[buffer(1)]],
-                             constant int& left [[buffer(2)]],
-                             constant int& bottom [[buffer(3)]],
-                             constant int& mosaic_pattern_width [[buffer(4)]],
-                             uint2 gid [[thread_position_in_grid]]) {
+kernel void sum_rect_columns_float(texture2d<float, access::read> in_texture [[texture(0)]],
+                                   texture2d<float, access::write> out_texture [[texture(1)]],
+                                   constant int& top [[buffer(1)]],
+                                   constant int& left [[buffer(2)]],
+                                   constant int& bottom [[buffer(3)]],
+                                   constant int& mosaic_pattern_width [[buffer(4)]],
+                                   uint2 gid [[thread_position_in_grid]]) {
+    uint x = left + gid.x;
+    uint dy = gid.y;
+    
+    float total = 0;
+    for (int y = top+dy; y < bottom; y += mosaic_pattern_width) {
+        total += in_texture.read(uint2(x, y)).r;
+    }
+
+    out_texture.write(total, gid);
+}
+
+
+kernel void sum_rect_columns_uint(texture2d<uint, access::read> in_texture [[texture(0)]],
+                                  texture2d<float, access::write> out_texture [[texture(1)]],
+                                  constant int& top [[buffer(1)]],
+                                  constant int& left [[buffer(2)]],
+                                  constant int& bottom [[buffer(3)]],
+                                  constant int& mosaic_pattern_width [[buffer(4)]],
+                                  uint2 gid [[thread_position_in_grid]]) {
     uint x = left + gid.x;
     uint dy = gid.y;
     

--- a/burstphoto/texture/texture.swift
+++ b/burstphoto/texture/texture.swift
@@ -6,10 +6,6 @@ let add_texture_state = try! device.makeComputePipelineState(function: mfl.makeF
 let add_texture_exposure_state = try! device.makeComputePipelineState(function: mfl.makeFunction(name: "add_texture_exposure")!)
 let add_texture_highlights_state = try! device.makeComputePipelineState(function: mfl.makeFunction(name: "add_texture_highlights")!)
 let add_texture_weighted_state = try! device.makeComputePipelineState(function: mfl.makeFunction(name: "add_texture_weighted")!)
-let average_x_state = try! device.makeComputePipelineState(function: mfl.makeFunction(name: "average_x")!)
-let average_y_state = try! device.makeComputePipelineState(function: mfl.makeFunction(name: "average_y")!)
-let average_x_rgba_state = try! device.makeComputePipelineState(function: mfl.makeFunction(name: "average_x_rgba")!)
-let average_y_rgba_state = try! device.makeComputePipelineState(function: mfl.makeFunction(name: "average_y_rgba")!)
 let blur_mosaic_texture_state = try! device.makeComputePipelineState(function: mfl.makeFunction(name: "blur_mosaic_texture")!)
 let convert_float_to_uint16_state = try! device.makeComputePipelineState(function: mfl.makeFunction(name: "convert_float_to_uint16")!)
 let convert_uint16_to_float_state = try! device.makeComputePipelineState(function: mfl.makeFunction(name: "convert_uint16_to_float")!)
@@ -19,18 +15,16 @@ let copy_texture_state = try! device.makeComputePipelineState(function: mfl.make
 let correct_hotpixels_bayer_state = try! device.makeComputePipelineState(function: mfl.makeFunction(name: "correct_hotpixels_bayer")!)
 let correct_hotpixels_xtrans_state = try! device.makeComputePipelineState(function: mfl.makeFunction(name: "correct_hotpixels_xtrans")!)
 let crop_texture_state = try! device.makeComputePipelineState(function: mfl.makeFunction(name: "crop_texture")!)
+let divide_buffer_state = try! device.makeComputePipelineState(function: mfl.makeFunction(name: "divide_buffer")!)
+let sum_divide_buffer_state = try! device.makeComputePipelineState(function: mfl.makeFunction(name: "sum_divide_buffer")!)
 let extend_texture_state = try! device.makeComputePipelineState(function: mfl.makeFunction(name: "extend_texture")!)
 let fill_with_zeros_state = try! device.makeComputePipelineState(function: mfl.makeFunction(name: "fill_with_zeros")!)
 let normalize_texture_state = try! device.makeComputePipelineState(function: mfl.makeFunction(name: "normalize_texture")!)
-let sum_rect_columns_state = try! device.makeComputePipelineState(function: mfl.makeFunction(name: "sum_rect_columns")!)
+let sum_rect_columns_float_state = try! device.makeComputePipelineState(function: mfl.makeFunction(name: "sum_rect_columns_float")!)
+let sum_rect_columns_uint_state = try! device.makeComputePipelineState(function: mfl.makeFunction(name: "sum_rect_columns_uint")!)
 let sum_row_state = try! device.makeComputePipelineState(function: mfl.makeFunction(name: "sum_row")!)
 let upsample_bilinear_float_state = try! device.makeComputePipelineState(function: mfl.makeFunction(name: "upsample_bilinear_float")!)
 let upsample_nearest_int_state = try! device.makeComputePipelineState(function: mfl.makeFunction(name: "upsample_nearest_int")!)
-
-enum PixelFormat {
-    case rgba
-    case r
-}
 
 enum UpsampleType {
     case Bilinear
@@ -196,10 +190,10 @@ func calculate_black_levels(for texture: MTLTexture, from_masked_areas masked_ar
         let command_buffer = command_queue.makeCommandBuffer()!
         let command_encoder = command_buffer.makeComputeCommandEncoder()!
         command_buffer.label = "Black Levels \(i) for \(String(describing: texture.label))"
-        command_encoder.setComputePipelineState(sum_rect_columns_state)
+        command_encoder.setComputePipelineState(sum_rect_columns_uint_state)
         let thread_groups_per_grid = MTLSize(width: summed_y.width, height: summed_y.height, depth: 1)
-        let max_threads_per_thread_group = sum_rect_columns_state.maxTotalThreadsPerThreadgroup
-        let threads_per_thread_group = get_threads_per_thread_group(sum_rect_columns_state, thread_groups_per_grid)
+        let max_threads_per_thread_group = sum_rect_columns_uint_state.maxTotalThreadsPerThreadgroup
+        let threads_per_thread_group = get_threads_per_thread_group(sum_rect_columns_uint_state, thread_groups_per_grid)
         
         command_encoder.setTexture(texture, index: 0)
         command_encoder.setTexture(summed_y, index: 1)
@@ -399,7 +393,9 @@ func correct_hotpixels(_ textures: [MTLTexture], _ black_level: [[Int]], _ ISO_e
         }
         
         // calculate mean value specific for each color channel
-        let mean_texture_buffer = texture_mean(convert_to_rgba(average_texture, 0, 0), .rgba)
+        let mean_texture_buffer = texture_mean(average_texture,
+                                               per_sub_pixel: true,
+                                               mosaic_pattern_width: mosaic_pattern_width)
         
         // standard parameters if black level is not available / available
         let hot_pixel_multiplicator = (black_level[0][0] == -1) ? 2.0 : 1.0
@@ -556,37 +552,59 @@ func texture_like(_ input_texture: MTLTexture) -> MTLTexture {
 }
 
 
-/// Function to calculate the average pixel value over the whole of a texture. If `pixelformat` is `rgba` then each channel will have an independent average calculated. Otherwise, a single value will be returned for the whole texture.
-func texture_mean(_ in_texture: MTLTexture, _ pixelformat: PixelFormat) -> MTLBuffer {
-    // create a 1d texture that will contain the averages of the input texture along the x-axis
-    let texture_descriptor = MTLTextureDescriptor()
-    texture_descriptor.textureType = .type1D
-    texture_descriptor.pixelFormat = in_texture.pixelFormat
-    texture_descriptor.width = in_texture.width
+/// Function to calculate the average pixel value over the whole of a texture.
+/// If `per_sub_pixel` is `true`, then each subpixel in the mosaic pattern will have an independent average calculated, producing a `pattern_width * pattern_width` buffer.
+/// If it's `false`, then a single value will be calculated for the whole texture.
+func texture_mean(_ in_texture: MTLTexture, per_sub_pixel: Bool, mosaic_pattern_width: Int) -> MTLBuffer {
+    
+    // Create output texture from the y-axis blurring
+    let texture_descriptor = MTLTextureDescriptor.texture2DDescriptor(pixelFormat: .r32Float, width: in_texture.width, height: mosaic_pattern_width, mipmapped: false)
     texture_descriptor.usage = [.shaderRead, .shaderWrite]
-    let avg_y = device.makeTexture(descriptor: texture_descriptor)!
-    
-    // average the input texture along the y-axis
+    let summed_y = device.makeTexture(descriptor: texture_descriptor)!
+
+    // Sum along columns
     let command_buffer = command_queue.makeCommandBuffer()!
-    command_buffer.label = "Mean"
     let command_encoder = command_buffer.makeComputeCommandEncoder()!
-    let state = (pixelformat == .rgba ? average_y_rgba_state : average_y_state)
-    command_encoder.setComputePipelineState(state)
-    let threads_per_grid = MTLSize(width: in_texture.width, height: 1, depth: 1)
-    let max_threads_per_thread_group = state.maxTotalThreadsPerThreadgroup
-    let threads_per_thread_group = MTLSize(width: max_threads_per_thread_group, height: 1, depth: 1)
-    command_encoder.setTexture(in_texture, index: 0)
-    command_encoder.setTexture(avg_y, index: 1)
-    command_encoder.dispatchThreads(threads_per_grid, threadsPerThreadgroup: threads_per_thread_group)
+    command_buffer.label = "Mean for \(String(describing: in_texture.label))\(per_sub_pixel ? " per_sub_pixel" : "")"
+    command_encoder.setComputePipelineState(sum_rect_columns_float_state)
+    let thread_groups_per_grid = MTLSize(width: summed_y.width, height: summed_y.height, depth: 1)
+    let threads_per_thread_group = get_threads_per_thread_group(sum_rect_columns_float_state, thread_groups_per_grid)
     
-    // average the generated 1D texture along the x-axis
-    let state2 = (pixelformat == .rgba ? average_x_rgba_state : average_x_state)
-    command_encoder.setComputePipelineState(state2)
-    let avg_buffer = device.makeBuffer(length: (pixelformat == .rgba ? 4 : 1)*MemoryLayout<Float32>.size, options: .storageModeShared)!
-    command_encoder.setTexture(avg_y, index: 0)
-    command_encoder.setBuffer(avg_buffer, offset: 0, index: 0)
-    command_encoder.setBytes([Int32(in_texture.width)], length: MemoryLayout<Int32>.stride, index: 1)
-    command_encoder.dispatchThreads(threads_per_grid, threadsPerThreadgroup: threads_per_thread_group)
+    command_encoder.setTexture(in_texture, index: 0)
+    command_encoder.setTexture(summed_y, index: 1)
+    command_encoder.setBytes([0], length: MemoryLayout<Int32>.stride, index: 1)
+    command_encoder.setBytes([0], length: MemoryLayout<Int32>.stride, index: 2)
+    command_encoder.setBytes([in_texture.height], length: MemoryLayout<Int32>.stride, index: 3)
+    command_encoder.setBytes([Int32(mosaic_pattern_width)], length: MemoryLayout<Int32>.stride, index: 4)
+    command_encoder.dispatchThreads(thread_groups_per_grid, threadsPerThreadgroup: threads_per_thread_group)
+
+    // Sum along the row
+    let sum_buffer = device.makeBuffer(length: (mosaic_pattern_width*mosaic_pattern_width)*MemoryLayout<Float32>.size,
+                                       options: .storageModeShared)!
+    let threads_per_grid_x = MTLSize(width: mosaic_pattern_width, height: mosaic_pattern_width, depth: 1)
+    let threads_per_thread_group_x = get_threads_per_thread_group(sum_row_state, threads_per_grid_x)
+    command_encoder.setComputePipelineState(sum_row_state)
+    command_encoder.setTexture(summed_y, index: 0)
+    command_encoder.setBuffer(sum_buffer, offset: 0, index: 0)
+    command_encoder.setBytes([Int32(summed_y.width)],       length: MemoryLayout<Int32>.stride, index: 1)
+    command_encoder.setBytes([Int32(mosaic_pattern_width)], length: MemoryLayout<Int32>.stride, index: 2)
+    // TODO: Should this have the same number of threads? I think it should only be 1 thread.
+    command_encoder.dispatchThreads(threads_per_grid_x, threadsPerThreadgroup: threads_per_thread_group_x)
+    
+    // Calculate the average from the sum
+    let state       = per_sub_pixel ? divide_buffer_state                       : sum_divide_buffer_state
+    let buffer_size = per_sub_pixel ? mosaic_pattern_width*mosaic_pattern_width : 1
+    let avg_buffer  = device.makeBuffer(length: buffer_size*MemoryLayout<Float32>.size, options: .storageModeShared)!
+    let num_pixels_per_value = Float(in_texture.width * in_texture.height)
+    let threads_per_grid_divisor = MTLSize(width: buffer_size, height: 1, depth: 1)
+    let threads_per_thread_group_divisor = get_threads_per_thread_group(state, threads_per_grid_divisor)
+    command_encoder.setComputePipelineState(state)
+    command_encoder.setBuffer(sum_buffer,                                   offset: 0,                            index: 0)
+    command_encoder.setBuffer(avg_buffer,                                   offset: 0,                            index: 1)
+    command_encoder.setBytes([num_pixels_per_value],                        length: MemoryLayout<Float32>.stride, index: 2)
+    command_encoder.setBytes([mosaic_pattern_width*mosaic_pattern_width],   length: MemoryLayout<Int>.stride,     index: 3)
+    command_encoder.dispatchThreads(threads_per_grid_divisor, threadsPerThreadgroup: threads_per_thread_group_divisor)
+    
     command_encoder.endEncoding()
     command_buffer.commit()
     


### PR DESCRIPTION
Enables the following features for X-Trans sensors:
- Exposure bracketing
- Hotpixel correction
    - Does not negatively impact the images I've seen, but none of them had a hot pixel (that I could find) so I have not been able to test if it correctly removes them.
- 16-bit output
    - Seems to work for DxO and Capture One, does not work for RawTherapee.

Closes #26.

Special thanks to @gigaturbo and @dejanberic who provided several X-Trans bursts in order to test much of this functionality.