### PR TITLE
Improved exposure bracketing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Burst Photo
 
-Burst Photo is a macOS app written in Swift / SwiftUI / Metal that implements a simplified version of HDR+, the computational photography pipeline in Google Pixel phones. With Burst Photo, this processing can be applied to a burst of images from any camera increasing dynamic range and reducing noise of the resulting image. You can read more about HDR+ in Google's paper [Burst photography for high dynamic range and low-light imaging on mobile cameras](http://static.googleusercontent.com/media/www.hdrplusdata.org/en//hdrplus.pdf).
+Burst Photo is a macOS app written in Swift / SwiftUI / Metal that implements a simplified version of HDR+, the computational photography pipeline in Google Pixel phones. With Burst Photo, this processing can be applied to a burst of images from any camera, increasing dynamic range and reducing noise of the resulting image. You can read more about HDR+ in Google's paper [Burst photography for high dynamic range and low-light imaging on mobile cameras](http://static.googleusercontent.com/media/www.hdrplusdata.org/en//hdrplus.pdf).
 
 If you are a researcher or you prefer Python/PyTorch, you can check out [hdr-plus-pytorch](https://github.com/martin-marek/hdr-plus-pytorch).
 

--- a/burstphoto/align/align.metal
+++ b/burstphoto/align/align.metal
@@ -577,7 +577,7 @@ kernel void find_best_tile_alignment(texture3d<float, access::read> tile_diff [[
 }
 
 
-kernel void warp_texture_Bayer(texture2d<half, access::read> in_texture [[texture(0)]],
+kernel void warp_texture_bayer(texture2d<half, access::read> in_texture [[texture(0)]],
                                texture2d<half, access::write> out_texture [[texture(1)]],
                                texture2d<int, access::read> prev_alignment [[texture(2)]],
                                constant int& downscale_factor [[buffer(0)]],
@@ -631,7 +631,7 @@ kernel void warp_texture_Bayer(texture2d<half, access::read> in_texture [[textur
 }
 
 
-kernel void warp_texture_XTrans(texture2d<float, access::read> in_texture [[texture(0)]],
+kernel void warp_texture_xtrans(texture2d<float, access::read> in_texture [[texture(0)]],
                                 texture2d<float, access::read_write> out_texture [[texture(1)]],
                                 texture2d<int, access::read> prev_alignment [[texture(2)]],
                                 constant int& downscale_factor [[buffer(0)]],

--- a/burstphoto/align/align.swift
+++ b/burstphoto/align/align.swift
@@ -8,8 +8,8 @@ let compute_tile_differences25_state = try! device.makeComputePipelineState(func
 let compute_tile_differences_exposure25_state = try! device.makeComputePipelineState(function: mfl.makeFunction(name: "compute_tile_differences_exposure25")!)
 let correct_upsampling_error_state = try! device.makeComputePipelineState(function: mfl.makeFunction(name: "correct_upsampling_error")!)
 let find_best_tile_alignment_state = try! device.makeComputePipelineState(function: mfl.makeFunction(name: "find_best_tile_alignment")!)
-let warp_texture_Bayer_state = try! device.makeComputePipelineState(function: mfl.makeFunction(name: "warp_texture_Bayer")!)
-let warp_texture_XTrans_state = try! device.makeComputePipelineState(function: mfl.makeFunction(name: "warp_texture_XTrans")!)
+let warp_texture_bayer_state = try! device.makeComputePipelineState(function: mfl.makeFunction(name: "warp_texture_bayer")!)
+let warp_texture_xtrans_state = try! device.makeComputePipelineState(function: mfl.makeFunction(name: "warp_texture_xtrans")!)
 
 func align_texture(_ ref_pyramid: [MTLTexture], _ comp_texture: MTLTexture, _ downscale_factor_array: Array<Int>, _ tile_size_array: Array<Int>, _ search_dist_array: Array<Int>, _ uniform_exposure: Bool, _ black_level_mean: Double, _ color_factors3: Array<Double>) -> MTLTexture {
         
@@ -223,8 +223,8 @@ func warp_texture(_ texture_to_warp: MTLTexture, _ alignment: MTLTexture, _ tile
     let command_buffer = command_queue.makeCommandBuffer()!
     command_buffer.label = "Warp Texture"
     let command_encoder = command_buffer.makeComputeCommandEncoder()!
-    // The function warp_texture_XTrans corresponds to an old version of the warp function and would also work with images with Bayer pattern
-    let state = (downscale_factor==2 ? warp_texture_Bayer_state : warp_texture_XTrans_state)
+    // The function warp_texture_xtrans corresponds to an old version of the warp function and would also work with images with Bayer pattern
+    let state = (downscale_factor==2 ? warp_texture_bayer_state : warp_texture_xtrans_state)
     command_encoder.setComputePipelineState(state)
     let threads_per_grid = MTLSize(width: texture_to_warp.width, height: texture_to_warp.height, depth: 1)
     let threads_per_thread_group = get_threads_per_thread_group(state, threads_per_grid)

--- a/burstphoto/denoise.swift
+++ b/burstphoto/denoise.swift
@@ -141,18 +141,18 @@ func perform_denoising(image_urls: [URL], progress: ProcessingProgress, merging_
     if uniform_exposure {
         for comp_idx in 0..<image_urls.count {
             // if images have different exposures: use image with lowest exposure as reference to protect highlights
-            if (ISO_exposure_time[ref_idx]-ISO_exposure_time[comp_idx] > 1e-15) {
+            if (ISO_exposure_time[ref_idx]-ISO_exposure_time[comp_idx] > 1e-12) {
                 ref_idx = comp_idx
             }
             // check if exposure is uniform or bracketed
-            if (abs(ISO_exposure_time[comp_idx]-ISO_exposure_time[0]) > 1e-15) {
+            if (abs(ISO_exposure_time[comp_idx]-ISO_exposure_time[0]) > 1e-12) {
                 uniform_exposure = false
             }
         }
-        // if exposure bracketing detected, overwrite exposure bias vector and set darkest frame to exposure bias -1EV
+        // if exposure bracketing is detected, overwrite exposure bias vector and set darkest frame to exposure bias -2EV
         if !uniform_exposure {
             for comp_idx in 0..<image_urls.count {
-                exposure_bias[comp_idx] = Int(round((log2(ISO_exposure_time[comp_idx]/ISO_exposure_time[ref_idx])-1.0)*100))
+                exposure_bias[comp_idx] = Int(round((log2(ISO_exposure_time[comp_idx]/ISO_exposure_time[ref_idx])-2.0)*100))
             }
         }
     }
@@ -220,7 +220,7 @@ func perform_denoising(image_urls: [URL], progress: ProcessingProgress, merging_
         } else if merging_algorithm == "Higher quality" {
             try align_merge_frequency_domain(progress: progress, ref_idx: ref_idx, mosaic_pattern_width: mosaic_pattern_width, search_distance: search_distance_dict[search_distance]!, tile_size: tile_size_dict[tile_size]!, noise_reduction: noise_reduction, uniform_exposure: uniform_exposure, exposure_bias: exposure_bias, white_level: white_level[ref_idx], black_level: black_level, color_factors: color_factors, textures: textures, final_texture: final_texture)
         } else {
-            try align_merge_spatial_domain(progress: progress, ref_idx: ref_idx, mosaic_pattern_width: mosaic_pattern_width, search_distance: search_distance_dict[search_distance]!, tile_size: tile_size_dict[tile_size]!, noise_reduction: noise_reduction, uniform_exposure: uniform_exposure, black_level: black_level, color_factors: color_factors, textures: textures, final_texture: final_texture)
+            try align_merge_spatial_domain(progress: progress, ref_idx: ref_idx, mosaic_pattern_width: mosaic_pattern_width, search_distance: search_distance_int, tile_size: tile_size_int, noise_reduction: noise_reduction, uniform_exposure: uniform_exposure, exposure_bias: exposure_bias, black_level: black_level, color_factors: color_factors, textures: textures, final_texture: final_texture)
         }
         last_texture = copy_texture(final_texture)
         last_settings = current_settings

--- a/burstphoto/denoise.swift
+++ b/burstphoto/denoise.swift
@@ -220,7 +220,7 @@ func perform_denoising(image_urls: [URL], progress: ProcessingProgress, merging_
         } else if merging_algorithm == "Higher quality" {
             try align_merge_frequency_domain(progress: progress, ref_idx: ref_idx, mosaic_pattern_width: mosaic_pattern_width, search_distance: search_distance_dict[search_distance]!, tile_size: tile_size_dict[tile_size]!, noise_reduction: noise_reduction, uniform_exposure: uniform_exposure, exposure_bias: exposure_bias, white_level: white_level[ref_idx], black_level: black_level, color_factors: color_factors, textures: textures, final_texture: final_texture)
         } else {
-            try align_merge_spatial_domain(progress: progress, ref_idx: ref_idx, mosaic_pattern_width: mosaic_pattern_width, search_distance: search_distance_int, tile_size: tile_size_int, noise_reduction: noise_reduction, uniform_exposure: uniform_exposure, exposure_bias: exposure_bias, black_level: black_level, color_factors: color_factors, textures: textures, final_texture: final_texture)
+            try align_merge_spatial_domain(progress: progress, ref_idx: ref_idx, mosaic_pattern_width: mosaic_pattern_width, search_distance: search_distance_dict[search_distance]!, tile_size: tile_size_dict[tile_size]!, noise_reduction: noise_reduction, uniform_exposure: uniform_exposure, exposure_bias: exposure_bias, black_level: black_level, color_factors: color_factors, textures: textures, final_texture: final_texture)
         }
         last_texture = copy_texture(final_texture)
         last_settings = current_settings

--- a/burstphoto/denoise.swift
+++ b/burstphoto/denoise.swift
@@ -132,8 +132,28 @@ func perform_denoising(image_urls: [URL], progress: ProcessingProgress, merging_
             ref_idx = comp_idx
         }
         // check if exposure is uniform or bracketed
-        if (exposure_bias[comp_idx] != exposure_bias[0]) {
+        if exposure_bias[comp_idx] != exposure_bias[0] {
             uniform_exposure = false
+        }
+    }
+    
+    // repeat check of uniform exposure, but this time use product of ISO value and exposure time for evaluation
+    if uniform_exposure {
+        for comp_idx in 0..<image_urls.count {
+            // if images have different exposures: use image with lowest exposure as reference to protect highlights
+            if (ISO_exposure_time[ref_idx]-ISO_exposure_time[comp_idx] > 1e-15) {
+                ref_idx = comp_idx
+            }
+            // check if exposure is uniform or bracketed
+            if (abs(ISO_exposure_time[comp_idx]-ISO_exposure_time[0]) > 1e-15) {
+                uniform_exposure = false
+            }
+        }
+        // if exposure bracketing detected, overwrite exposure bias vector and set darkest frame to exposure bias -1EV
+        if !uniform_exposure {
+            for comp_idx in 0..<image_urls.count {
+                exposure_bias[comp_idx] = Int(round((log2(ISO_exposure_time[comp_idx]/ISO_exposure_time[ref_idx])-1.0)*100))
+            }
         }
     }
     
@@ -161,7 +181,6 @@ func perform_denoising(image_urls: [URL], progress: ProcessingProgress, merging_
         DispatchQueue.main.async { progress.show_nonbayer_hq_alert = true }
         merging_algorithm = "Fast"
     }
-
 
     // if user has selected the "16Bit" output bit depth but has a non-Bayer sensor, warn them the "Native" output bit depth will be used instead
     var output_bit_depth = output_bit_depth

--- a/burstphoto/merge/frequency.swift
+++ b/burstphoto/merge/frequency.swift
@@ -168,7 +168,7 @@ func align_merge_frequency_domain(progress: ProcessingProgress, ref_idx: Int, mo
             
             // align comparison texture
             let aligned_texture_rgba = convert_to_rgba(
-                align_texture(ref_pyramid, comp_texture, downscale_factor_array, tile_size_array, search_dist_array, uniform_exposure, black_level_mean, color_factors[comp_idx]),
+                align_texture(ref_pyramid, comp_texture, downscale_factor_array, tile_size_array, search_dist_array, (exposure_bias[comp_idx]==exposure_bias[ref_idx]), black_level_mean, color_factors[comp_idx]),
                 crop_merge_x,
                 crop_merge_y
             )
@@ -188,12 +188,6 @@ func align_merge_frequency_domain(progress: ProcessingProgress, ref_idx: Int, mo
          
             let highlights_norm_texture = calculate_highlights_norm_rgba(aligned_texture_rgba, exposure_factor, tile_info_merge, (white_level == -1 ? 1000000 : white_level), black_level_mean)
             
-            // start debug capture
-            //let capture_manager = MTLCaptureManager.shared()
-            //let capture_descriptor = MTLCaptureDescriptor()
-            //capture_descriptor.captureObject = device
-            //try! capture_manager.startCapture(with: capture_descriptor)
-            
             // transform aligned comparison texture into the frequency domain
             forward_ft(aligned_texture_rgba, aligned_texture_ft, tmp_texture_ft, tile_info_merge)
             
@@ -202,9 +196,6 @@ func align_merge_frequency_domain(progress: ProcessingProgress, ref_idx: Int, mo
             
             // merge aligned comparison texture with reference texture in the frequency domain
             merge_frequency_domain(ref_texture_ft, aligned_texture_ft, final_texture_ft, rms_texture, mismatch_texture, highlights_norm_texture, robustness_norm, read_noise, max_motion_norm_exposure, uniform_exposure, tile_info_merge)
-            
-            // stop debug capture
-            //capture_manager.stopCapture()
             
             // sync GUI progress
             DispatchQueue.main.async { progress.int += Int(80000000/Double(4*(textures.count-1))) }


### PR DESCRIPTION
The exposure bias information required for processing exposure bracketed bursts can now be derived either from the DNG metadata or from the product of ISO value and exposure time (shutter speed). For the latter, only a relative exposure bias can be calculated between the frames and an exposure bias of -2EV is assumed for the darkest frame.