### PR TITLE
Improved averaging of exposure bracketed bursts

### DIFF
--- a/burstphoto/denoise.swift
+++ b/burstphoto/denoise.swift
@@ -336,7 +336,7 @@ func calculate_temporal_average(progress: ProcessingProgress, mosaic_pattern_wid
                        
             if exposure_bias[comp_idx] == exposure_bias[exp_idx] {
                 // for uniform exposure or for the darkest frame in an exposure bracketed burst: add frame and apply extrapolation of green channels for very bright pixels. All pixels in the frame get the same global weight of 1. Therefore a scalar value for normalization storing the sum of accumulated frames is sufficient.
-                add_texture_highlights(comp_texture, final_texture, 1, white_level, black_level[comp_idx], color_factors[comp_idx])
+                add_texture_highlights(comp_texture, final_texture, white_level, black_level[comp_idx], color_factors[comp_idx])
                 norm_scalar += 1
             } else {
                 // for all frames of a bracketed expsoure besides the darkest frame: add frame with exposure-weighting and exclude regions with clipped highlights. Due to the exposure weighting, frames typically have weights > 1. Inside the function, pixel weights are further adapted based on their brightness: in the shadows, weights are linear with exposure. In the midtones/highlights, this converges towards weights being linear with the square-root of exposure. For clipped highlight pixels, the weight becomes zero. As the weights are pixel-specific, a texture for normalization is employed storing the sum of pixel-specific weights.

--- a/burstphoto/denoise.swift
+++ b/burstphoto/denoise.swift
@@ -321,31 +321,40 @@ func calculate_temporal_average(progress: ProcessingProgress, mosaic_pattern_wid
     // if color_factor is NOT available, it is set to a negative value earlier in the pipeline
     if (white_level != -1 && black_level[0][0] != -1 && color_factors[0][0] > 0 && mosaic_pattern_width == 2) {
         
-        // initialize weight texture used for normalization of the final image
+        // Temporal averaging with extrapolation of highlights or exposure weighting
+        
+        // The averaging is performed in two steps:
+        // 1. add all frames of the burst
+        // 2. divide the resulting sum of frames by a pixel-specific norm to get the final image
+        
+        // The pixel-specific norm has two contributions: norm(x, y) = norm_texture(x, y) + norm_scalar
+        // - pixel-specific values calculated by add_texture_exposure() accounting for the different weight given to each pixel based on its brightness
+        // - a global scalar if a given frame has the same exposure as the reference frame, which has the darkest exposure
+        //
+        // For the latter, a single scalar is used as it is more efficient than adding a single, uniform value to each individual pixel in norm_texture 
+        
         let norm_texture_descriptor = MTLTextureDescriptor.texture2DDescriptor(pixelFormat: .r32Float, width: final_texture.width, height: final_texture.height, mipmapped: false)
         norm_texture_descriptor.usage = [.shaderRead, .shaderWrite]
         norm_texture_descriptor.storageMode = .private
         let norm_texture = device.makeTexture(descriptor: norm_texture_descriptor)!
         fill_with_zeros(norm_texture)
-        // initialize scalar weight used for normalization of the final image
+
         var norm_scalar = 0
         
-        // temporal averaging with extrapolation of highlights or exposure weighting
+        // 1. add up all frames of the burst
         for comp_idx in 0..<textures.count {
             let comp_texture = prepare_texture(textures[comp_idx], hotpixel_weight_texture, 0, 0, 0, 0, exposure_bias[exp_idx]-exposure_bias[comp_idx], black_level, comp_idx)
                        
             if exposure_bias[comp_idx] == exposure_bias[exp_idx] {
-                // for uniform exposure or for the darkest frame in an exposure bracketed burst: add frame and apply extrapolation of green channels for very bright pixels. All pixels in the frame get the same global weight of 1. Therefore a scalar value for normalization storing the sum of accumulated frames is sufficient.
                 add_texture_highlights(comp_texture, final_texture, white_level, black_level[comp_idx], color_factors[comp_idx])
                 norm_scalar += 1
             } else {
-                // for all frames of a bracketed expsoure besides the darkest frame: add frame with exposure-weighting and exclude regions with clipped highlights. Due to the exposure weighting, frames typically have weights > 1. Inside the function, pixel weights are further adapted based on their brightness: in the shadows, weights are linear with exposure. In the midtones/highlights, this converges towards weights being linear with the square-root of exposure. For clipped highlight pixels, the weight becomes zero. As the weights are pixel-specific, a texture for normalization is employed storing the sum of pixel-specific weights.
                 add_texture_exposure(comp_texture, final_texture, norm_texture, exposure_bias[comp_idx]-exposure_bias[exp_idx], white_level, black_level[comp_idx], color_factors[comp_idx])
             }
             DispatchQueue.main.async { progress.int += Int(80_000_000/Double(textures.count)) }
         }
-        
-        // normalization of the final image with pixel-specific norm_texture and scalar value stored in norm_scalar. The sum of pixel-specific weights and the scalar sum of accumulated frames is then used for normalization of the final texture.
+     
+        // 2. divide the sum of frames by a per-pixel norm to get the final image
         normalize_texture(final_texture, norm_texture, norm_scalar)
     
     } else {

--- a/burstphoto/exposure/exposure.swift
+++ b/burstphoto/exposure/exposure.swift
@@ -65,6 +65,8 @@ func correct_exposure(_ final_texture: MTLTexture, _ white_level: Int, _ black_l
        
         if (exposure_control=="Curve0EV" || exposure_control=="Curve1EV") {
             let color_factor_mean = 0.25*(color_factors[ref_idx][0]+2.0*color_factors[ref_idx][1]+color_factors[ref_idx][2])
+            
+            // the blurred texture serves as an approximation of local luminance
             final_texture_blurred = blur(final_texture, with_pattern_width: 1, using_kernel_size: 1)
             
             command_encoder.setTexture(final_texture_blurred, index: 0)

--- a/burstphoto/texture/texture.metal
+++ b/burstphoto/texture/texture.metal
@@ -15,56 +15,37 @@ kernel void add_texture(texture2d<float, access::read> in_texture [[texture(0)]]
 
 
 kernel void add_texture_exposure(texture2d<float, access::read> in_texture [[texture(0)]],
-                                 texture2d<float, access::read_write> out_texture [[texture(1)]],
-                                 texture2d<float, access::read_write> norm_texture [[texture(2)]],
+                                 texture2d<float, access::read> in_texture_blurred [[texture(1)]],
+                                 texture2d<float, access::read> weight_highlights_texture [[texture(2)]],
+                                 texture2d<float, access::read_write> out_texture [[texture(3)]],
+                                 texture2d<float, access::read_write> norm_texture [[texture(4)]],
                                  constant int& exposure_bias [[buffer(0)]],
                                  constant float& white_level [[buffer(1)]],
                                  constant float& black_level_mean [[buffer(2)]],
+                                 constant float& color_factor_mean [[buffer(3)]],
                                  uint2 gid [[thread_position_in_grid]]) {
        
-    // load args
-    int texture_width  = in_texture.get_width();
-    int texture_height = in_texture.get_height();
-    
     // calculate weight based on exposure bias
-    float const weight_exposure = pow(2.0f, float(exposure_bias/100.0f));
+    float weight_exposure = pow(2.0f, float(exposure_bias/100.0f));
     
     // extract pixel value
     float pixel_value = in_texture.read(gid).r;
     
-    // find the maximum intensity in a 5x5 window around the main pixel
-    float pixel_value_max = 0.0f;
-      
-    for (int dy = -2; dy <= 2; dy++) {
-        int y = gid.y + dy;
-        
-        if (0 <= y && y < texture_height) {
-            for (int dx = -2; dx <= 2; dx++) {
-                int x = gid.x + dx;
-                
-                if (0 <= x && x < texture_width) {
-                    pixel_value_max = max(pixel_value_max, in_texture.read(uint2(x, y)).r);
-                }
-            }
-        }
-    }
-    
-    pixel_value_max = (pixel_value_max-black_level_mean)*weight_exposure + black_level_mean;
-    
-    float weight_pixel_value = 1.0f;
-    
-    // this ensures that pixels of the image with lowest exposure are always added
-    if (white_level < 999999.0f) {
-        // ensure smooth blending for pixel values between 0.25 and 0.99 of the white level
-        weight_pixel_value = clamp(0.99f/0.74f-1.0f/0.74f*pixel_value_max/white_level, 0.0f, 1.0f);
-    }
+    // adapt exposure weight based on the luminosity of each pixel
+    // shadows get the exposure-dependent weight for optimal noise reduction while midtones and highlights have a reduced weight for better motion robustness
+    // between 0.25 and 1.00 of the white level (based on pixel values after exposure correction), the weight becomes 1.0
+    float const luminance = min(white_level, in_texture_blurred.read(gid).r/color_factor_mean);
+    weight_exposure = max(sqrt(weight_exposure), weight_exposure * pow(weight_exposure, -0.5f/(0.25f-black_level_mean/white_level)*(luminance-black_level_mean)/white_level));
    
+    // ensure smooth blending for pixel values between 0.25 and 0.99 of the white level (based on pixel values before exposure correction)
+    float const weight_highlights = weight_highlights_texture.read(gid).r;
+       
     // apply optimal weight based on exposure of pixel and take into account weight based on the pixel intensity
-    pixel_value = weight_exposure*weight_pixel_value * pixel_value;
+    pixel_value = weight_exposure*weight_highlights * pixel_value;
     
     out_texture.write(out_texture.read(gid).r + pixel_value, gid);
     
-    norm_texture.write(norm_texture.read(gid).r + weight_exposure*weight_pixel_value, gid);
+    norm_texture.write(norm_texture.read(gid).r + weight_exposure*weight_highlights, gid);
 }
 
 
@@ -321,6 +302,47 @@ kernel void blur_mosaic_texture(texture2d<float, access::read> in_texture [[text
 }
 
 
+kernel void calculate_weight_highlights(texture2d<float, access::read> in_texture [[texture(0)]],
+                                        texture2d<float, access::write> weight_highlights_texture [[texture(1)]],
+                                        constant int& exposure_bias [[buffer(0)]],
+                                        constant float& white_level [[buffer(1)]],
+                                        constant float& black_level_mean [[buffer(2)]],
+                                        constant int& kernel_size [[buffer(3)]],
+                                        uint2 gid [[thread_position_in_grid]]) {
+       
+    // load args
+    int texture_width  = in_texture.get_width();
+    int texture_height = in_texture.get_height();
+    
+    // calculate weight based on exposure bias
+    float const weight_exposure = pow(2.0f, float(exposure_bias/100.0f));
+    
+    // find the maximum intensity in a 5x5 window around the main pixel
+    float pixel_value_max = 0.0f;
+      
+    for (int dy = -kernel_size; dy <= kernel_size; dy++) {
+        int y = gid.y + dy;
+        
+        if (0 <= y && y < texture_height) {
+            for (int dx = -kernel_size; dx <= kernel_size; dx++) {
+                int x = gid.x + dx;
+                
+                if (0 <= x && x < texture_width) {
+                    pixel_value_max = max(pixel_value_max, in_texture.read(uint2(x, y)).r);
+                }
+            }
+        }
+    }
+    
+    pixel_value_max = (pixel_value_max-black_level_mean)*weight_exposure + black_level_mean;
+
+    // ensure smooth blending for pixel values between 0.25 and 0.99 of the white level (based on pixel values before exposure correction)
+    float const weight_highlights = clamp(0.99f/0.74f-1.0f/0.74f*pixel_value_max/white_level, 0.0f, 1.0f);
+      
+    weight_highlights_texture.write(weight_highlights, gid);
+}
+
+
 kernel void convert_float_to_uint16(texture2d<float, access::read> in_texture [[texture(0)]],
                                     texture2d<uint, access::write> out_texture [[texture(1)]],
                                     constant int& white_level [[buffer(0)]],
@@ -531,8 +553,10 @@ kernel void prepare_texture(texture2d<uint, access::read> in_texture [[texture(0
 
 kernel void normalize_texture(texture2d<float, access::read_write> in_texture [[texture(0)]],
                               texture2d<float, access::read> norm_texture [[texture(1)]],
+                              constant float& norm_counter [[buffer(0)]],
                               uint2 gid [[thread_position_in_grid]]) {
-    in_texture.write(in_texture.read(gid).r/norm_texture.read(gid).r, gid);
+    
+    in_texture.write(in_texture.read(gid).r/(norm_texture.read(gid).r + norm_counter), gid);
 }
 
 

--- a/burstphoto/texture/texture.metal
+++ b/burstphoto/texture/texture.metal
@@ -553,10 +553,10 @@ kernel void prepare_texture(texture2d<uint, access::read> in_texture [[texture(0
 
 kernel void normalize_texture(texture2d<float, access::read_write> in_texture [[texture(0)]],
                               texture2d<float, access::read> norm_texture [[texture(1)]],
-                              constant float& norm_counter [[buffer(0)]],
+                              constant float& norm_scalar [[buffer(0)]],
                               uint2 gid [[thread_position_in_grid]]) {
     
-    in_texture.write(in_texture.read(gid).r/(norm_texture.read(gid).r + norm_counter), gid);
+    in_texture.write(in_texture.read(gid).r/(norm_texture.read(gid).r + norm_scalar), gid);
 }
 
 

--- a/burstphoto/texture/texture.swift
+++ b/burstphoto/texture/texture.swift
@@ -55,6 +55,7 @@ func add_texture(_ in_texture: MTLTexture, _ out_texture: MTLTexture, _ n_textur
 }
 
 
+/// This function is intended for averaging of frames with uniform exposure or for adding the darkest frame in an exposure bracketed burst: add frame and apply extrapolation of green channels for very bright pixels. All pixels in the frame get the same global weight of 1. Therefore a scalar value for normalization storing the sum of accumulated frames is sufficient.
 func add_texture_highlights(_ in_texture: MTLTexture, _ out_texture: MTLTexture, _ white_level: Int, _ black_level: [Int], _ color_factors: [Double]) {
     
     let black_level_mean = 0.25*Double(black_level[0] + black_level[1] + black_level[2] + black_level[3])
@@ -78,6 +79,7 @@ func add_texture_highlights(_ in_texture: MTLTexture, _ out_texture: MTLTexture,
 }
 
 
+/// This function is intended for adding up all frames of a bracketed expsoure besides the darkest frame: add frame with exposure-weighting and exclude regions with clipped highlights. Due to the exposure weighting, frames typically have weights > 1. Inside the function, pixel weights are further adapted based on their brightness: in the shadows, weights are linear with exposure. In the midtones/highlights, this converges towards weights being linear with the square-root of exposure. For clipped highlight pixels, the weight becomes zero. As the weights are pixel-specific, a texture for normalization is employed storing the sum of pixel-specific weights.
 func add_texture_exposure(_ in_texture: MTLTexture, _ out_texture: MTLTexture, _ norm_texture: MTLTexture, _ exposure_bias: Int, _ white_level: Int, _ black_level: [Int], _ color_factors: [Double]) {
     
     let black_level_mean = 0.25*Double(black_level[0] + black_level[1] + black_level[2] + black_level[3])

--- a/burstphoto/texture/texture.swift
+++ b/burstphoto/texture/texture.swift
@@ -553,7 +553,7 @@ func get_threads_per_thread_group(_ state: MTLComputePipelineState, _ threads_pe
 }
 
 
-func normalize_texture(_ in_texture: MTLTexture, _ norm_texture: MTLTexture, _ norm_counter: Int) {
+func normalize_texture(_ in_texture: MTLTexture, _ norm_texture: MTLTexture, _ norm_scalar: Int) {
     
     let command_buffer = command_queue.makeCommandBuffer()!
     command_buffer.label = "Normalize Texture"
@@ -564,7 +564,7 @@ func normalize_texture(_ in_texture: MTLTexture, _ norm_texture: MTLTexture, _ n
     let threads_per_thread_group = get_threads_per_thread_group(state, threads_per_grid)
     command_encoder.setTexture(in_texture, index: 0)
     command_encoder.setTexture(norm_texture, index: 1)
-    command_encoder.setBytes([Float32(norm_counter)], length: MemoryLayout<Float32>.stride, index: 0)
+    command_encoder.setBytes([Float32(norm_scalar)], length: MemoryLayout<Float32>.stride, index: 0)
     command_encoder.dispatchThreads(threads_per_grid, threadsPerThreadgroup: threads_per_thread_group)
     command_encoder.endEncoding()
     command_buffer.commit()

--- a/docs/_pages/guide.md
+++ b/docs/_pages/guide.md
@@ -59,6 +59,6 @@ Some example configurations and potential applications are shown in the table be
 |:-------------:|:---------------:|:-----------------:|:--------:|
 | uniform exposure; NR: 1 to 22          | +    | +++ | night scene, astro photography |
 | bracketed exposure; NR: 1 to 22        | ++   | ++  | daylight HDR scene |
-| uniform exposure; NR: simple average   | +++  | -   | static scene with tripod, virtual long exposure |
-| bracketed exposure; NR: simple average | ++++ | --  | static HDR scene with tripod |
+| uniform exposure; NR: simple average   | +++  | &minus; | static scene with tripod, virtual long exposure |
+| bracketed exposure; NR: simple average | ++++ | &minus; &minus; | static HDR scene with tripod |
 


### PR DESCRIPTION
This PR improves the "simple" averaging (without alignment) of exposure bracketed bursts.

It includes two fixes for regions with clipped highlights when these regions change their position between frames due to strong motion:
- Fix of magenta cast in the final image when darkest frame in the burst has clipped highlights and there is a lot of motion between frames
- Fix of "blocky" artifacts and sharp transitions in the final image when all other frames in the burst have clipped highlights and there is a lot of motion between frames

The mode "simple" averaging (without alignment) is obviously not designed for scenes with strong motion as it leads to ghosting in the image. For these situations, the robust merging algorithms (NR 1 - 22) are highly recommended. Still there might be scenes with only very slight motion, for which the most efficient noise reduction is desirable, e.g. landscapes with slightly moving trees. For these situations, the fixes yield a welcome improvement. When the ghosting effect shall be used as an artistic effect, the "simple" averaging of bursts with uniform exposure may be better suited as each frame gets exactly the same weight in the final image.

The example below shows a strong crop of a scene with a spinning top, which reveals very strong motion between the frames. It is recommended to inspect the example at 100% zoom level.

![Bildschirmfoto 2023-10-22 um 22 52 15](https://github.com/martin-marek/hdr-plus-swift/assets/117006531/81ac048b-4082-48d5-8211-b053174ba588)
