### PR TITLE
Added labels to textures to make debugging easier

### DIFF
--- a/burstphoto/align/align.swift
+++ b/burstphoto/align/align.swift
@@ -20,7 +20,7 @@ func align_texture(_ ref_pyramid: [MTLTexture], _ comp_texture: MTLTexture, _ do
     var prev_alignment = device.makeTexture(descriptor: alignment_descriptor)!
     
     var current_alignment = device.makeTexture(descriptor: alignment_descriptor)!
-    current_alignment.label = "\(comp_texture.label!.components(separatedBy: ":")[0]): Current alignment 0"
+    current_alignment.label = "\(comp_texture.label!.components(separatedBy: ":")[0]): Current alignment Start"
     var tile_info = TileInfo(tile_size: 0, tile_size_merge: 0, search_dist: 0, n_tiles_x: 0, n_tiles_y: 0, n_pos_1d: 0, n_pos_2d: 0)
     
     // build comparison pyramid
@@ -227,10 +227,7 @@ func find_best_tile_alignment(_ tile_diff: MTLTexture, _ prev_alignment: MTLText
 
 func warp_texture(_ texture_to_warp: MTLTexture, _ alignment: MTLTexture, _ tile_info: TileInfo, _ downscale_factor: Int) -> MTLTexture {
     
-    let warped_texture_descriptor = MTLTextureDescriptor.texture2DDescriptor(pixelFormat: texture_to_warp.pixelFormat,
-                                                                             width: texture_to_warp.width,
-                                                                             height: texture_to_warp.height,
-                                                                             mipmapped: false)
+    let warped_texture_descriptor = MTLTextureDescriptor.texture2DDescriptor(pixelFormat: texture_to_warp.pixelFormat, width: texture_to_warp.width, height: texture_to_warp.height, mipmapped: false)
     warped_texture_descriptor.usage = [.shaderRead, .shaderWrite]
     warped_texture_descriptor.storageMode = .private
     let warped_texture = device.makeTexture(descriptor: warped_texture_descriptor)!

--- a/burstphoto/align/align.swift
+++ b/burstphoto/align/align.swift
@@ -18,7 +18,9 @@ func align_texture(_ ref_pyramid: [MTLTexture], _ comp_texture: MTLTexture, _ do
     alignment_descriptor.usage = [.shaderRead, .shaderWrite]
     alignment_descriptor.storageMode = .private
     var prev_alignment = device.makeTexture(descriptor: alignment_descriptor)!
+    
     var current_alignment = device.makeTexture(descriptor: alignment_descriptor)!
+    current_alignment.label = "\(comp_texture.label!.components(separatedBy: ":")[0]): Current alignment 0"
     var tile_info = TileInfo(tile_size: 0, tile_size_merge: 0, search_dist: 0, n_tiles_x: 0, n_tiles_y: 0, n_pos_1d: 0, n_pos_2d: 0)
     
     // build comparison pyramid
@@ -53,6 +55,7 @@ func align_texture(_ ref_pyramid: [MTLTexture], _ comp_texture: MTLTexture, _ do
         
         // upsample alignment vectors by a factor of 2
         prev_alignment = upsample(current_alignment, to_width: n_tiles_x, to_height: n_tiles_y, using: .NearestNeighbour)
+        prev_alignment.label = "\(comp_texture.label!.components(separatedBy: ":")[0]): Prev alignment \(i)"
         
         // compare three alignment vector candidates, which improves alignment at borders of moving object
         // see https://graphics.stanford.edu/papers/hdrp/hasinoff-hdrplus-sigasia16.pdf for more details
@@ -65,6 +68,7 @@ func align_texture(_ ref_pyramid: [MTLTexture], _ comp_texture: MTLTexture, _ do
         let tile_diff = compute_tile_diff(ref_layer, comp_layer, prev_alignment, downscale_factor, uniform_exposure, (i != 0), tile_info)
       
         current_alignment = texture_like(prev_alignment)
+        current_alignment.label = "\(comp_texture.label!.components(separatedBy: ":")[0]): Current alignment \(i)"
         
         // find best tile alignment based on tile differences
         find_best_tile_alignment(tile_diff, prev_alignment, current_alignment, downscale_factor, tile_info)
@@ -84,6 +88,7 @@ func avg_pool(_ input_texture: MTLTexture, _ scale: Int, _ black_level_mean: Dou
     output_texture_descriptor.usage = [.shaderRead, .shaderWrite]
     output_texture_descriptor.storageMode = .private
     let output_texture = device.makeTexture(descriptor: output_texture_descriptor)!
+    output_texture.label = "\(input_texture.label!.components(separatedBy: ":")[0]): pool w/ scale \(scale)"
     
     let command_buffer = command_queue.makeCommandBuffer()!
     command_buffer.label = "Avg Pool"
@@ -139,7 +144,8 @@ func compute_tile_diff(_ ref_layer: MTLTexture, _ comp_layer: MTLTexture, _ prev
     texture_descriptor.usage = [.shaderRead, .shaderWrite]
     texture_descriptor.storageMode = .private
     let tile_diff = device.makeTexture(descriptor: texture_descriptor)!
-
+    tile_diff.label = "\(comp_layer.label!.components(separatedBy: ":")[0]): Tile diff"
+    
     // compute tile differences
     let command_buffer = command_queue.makeCommandBuffer()!
     command_buffer.label = "Compute Tile Diff"
@@ -172,7 +178,8 @@ func correct_upsampling_error(_ ref_layer: MTLTexture, _ comp_layer: MTLTexture,
     prev_alignment_corrected_descriptor.usage = [.shaderRead, .shaderWrite]
     prev_alignment_corrected_descriptor.storageMode = .private
     let prev_alignment_corrected = device.makeTexture(descriptor: prev_alignment_corrected_descriptor)!
-  
+    prev_alignment_corrected.label = "\(prev_alignment.label!.components(separatedBy: ":")[0]): Prev alignment upscaled corrected"
+        
     let command_buffer = command_queue.makeCommandBuffer()!
     command_buffer.label = "Correct Upsampling Error"
     let command_encoder = command_buffer.makeComputeCommandEncoder()!
@@ -220,10 +227,14 @@ func find_best_tile_alignment(_ tile_diff: MTLTexture, _ prev_alignment: MTLText
 
 func warp_texture(_ texture_to_warp: MTLTexture, _ alignment: MTLTexture, _ tile_info: TileInfo, _ downscale_factor: Int) -> MTLTexture {
     
-    let warped_texture_descriptor = MTLTextureDescriptor.texture2DDescriptor(pixelFormat: texture_to_warp.pixelFormat, width: texture_to_warp.width, height: texture_to_warp.height, mipmapped: false)
+    let warped_texture_descriptor = MTLTextureDescriptor.texture2DDescriptor(pixelFormat: texture_to_warp.pixelFormat,
+                                                                             width: texture_to_warp.width,
+                                                                             height: texture_to_warp.height,
+                                                                             mipmapped: false)
     warped_texture_descriptor.usage = [.shaderRead, .shaderWrite]
     warped_texture_descriptor.storageMode = .private
     let warped_texture = device.makeTexture(descriptor: warped_texture_descriptor)!
+    warped_texture.label = "\(texture_to_warp.label!.components(separatedBy: ":")[0]): warped"
     
     let command_buffer = command_queue.makeCommandBuffer()!
     command_buffer.label = "Warp Texture"

--- a/burstphoto/denoise.swift
+++ b/burstphoto/denoise.swift
@@ -213,6 +213,7 @@ func perform_denoising(image_urls: [URL], progress: ProcessingProgress, merging_
         hotpixel_weight_texture_descriptor.usage = [.shaderRead, .shaderWrite]
         hotpixel_weight_texture_descriptor.storageMode = .private
         let hotpixel_weight_texture = device.makeTexture(descriptor: hotpixel_weight_texture_descriptor)!
+        hotpixel_weight_texture.label = "Hotpixel weight texture"
         fill_with_zeros(hotpixel_weight_texture)
                 
         if mosaic_pattern_width == 2 {

--- a/burstphoto/denoise.swift
+++ b/burstphoto/denoise.swift
@@ -206,6 +206,7 @@ func perform_denoising(image_urls: [URL], progress: ProcessingProgress, merging_
         final_texture_descriptor.usage = [.shaderRead, .shaderWrite]
         final_texture_descriptor.storageMode = .private
         final_texture = device.makeTexture(descriptor: final_texture_descriptor)!
+        final_texture.label = "Final Texture"
         fill_with_zeros(final_texture)
         
         let hotpixel_weight_texture_descriptor = MTLTextureDescriptor.texture2DDescriptor(pixelFormat: .r16Float, width: textures[ref_idx].width, height: textures[ref_idx].height, mipmapped: false)
@@ -337,6 +338,7 @@ func calculate_temporal_average(progress: ProcessingProgress, mosaic_pattern_wid
         norm_texture_descriptor.usage = [.shaderRead, .shaderWrite]
         norm_texture_descriptor.storageMode = .private
         let norm_texture = device.makeTexture(descriptor: norm_texture_descriptor)!
+        norm_texture.label = "Norm Texture"
         fill_with_zeros(norm_texture)
 
         var norm_scalar = 0

--- a/burstphoto/exposure/exposure.swift
+++ b/burstphoto/exposure/exposure.swift
@@ -109,6 +109,7 @@ func texture_max(_ in_texture: MTLTexture) -> MTLBuffer {
     texture_descriptor.usage = [.shaderRead, .shaderWrite]
     texture_descriptor.storageMode = .private
     let max_y = device.makeTexture(descriptor: texture_descriptor)!
+    max_y.label = "\(in_texture.label!.components(separatedBy: ":")[0]): Max y"
     
     // average the input texture along the y-axis
     let command_buffer = command_queue.makeCommandBuffer()!
@@ -127,6 +128,7 @@ func texture_max(_ in_texture: MTLTexture) -> MTLBuffer {
     let state2 = max_x_state
     command_encoder.setComputePipelineState(state2)
     let max_buffer = device.makeBuffer(length: MemoryLayout<Float32>.size, options: .storageModeShared)!
+    max_buffer.label = "\(in_texture.label!.components(separatedBy: ":")[0]): Max"
     command_encoder.setTexture(max_y, index: 0)
     command_encoder.setBuffer(max_buffer, offset: 0, index: 0)
     command_encoder.setBytes([Int32(in_texture.width)], length: MemoryLayout<Int32>.stride, index: 1)

--- a/burstphoto/io_dng/io_dng_sdk.swift
+++ b/burstphoto/io_dng/io_dng_sdk.swift
@@ -141,8 +141,10 @@ func image_url_to_texture(_ url: URL, _ device: MTLDevice) throws -> (MTLTexture
     let texture_descriptor = MTLTextureDescriptor.texture2DDescriptor(pixelFormat: .r16Uint, width: Int(width), height: Int(height), mipmapped: false)
     texture_descriptor.usage = .shaderRead
     guard let texture = device.makeTexture(descriptor: texture_descriptor) else {throw ImageIOError.metal_error}
-    let mtl_region = MTLRegionMake2D(0, 0, Int(width), Int(height))
-    texture.replace(region: mtl_region, mipmapLevel: 0, withBytes: pixel_bytes!, bytesPerRow: bytes_per_row)
+    texture.label = url.lastPathComponent
+    
+    texture.replace(region: MTLRegionMake2D(0, 0, Int(width), Int(height)), mipmapLevel: 0, withBytes: pixel_bytes!, bytesPerRow: bytes_per_row)
+    
     
     free(pixel_bytes!)
 

--- a/burstphoto/merge/frequency.metal
+++ b/burstphoto/merge/frequency.metal
@@ -405,7 +405,7 @@ kernel void normalize_mismatch(texture2d<float, access::read_write> mismatch_tex
 }
 
 
-kernel void reduce_artifacts_tile_border(texture2d<float, access::read_write> output_texture [[texture(0)]],
+kernel void reduce_artifacts_tile_border(texture2d<float, access::read_write> out_texture [[texture(0)]],
                                          texture2d<float, access::read> ref_texture [[texture(1)]],
                                          constant int& tile_size [[buffer(0)]],
                                          constant int& black_level0 [[buffer(1)]],
@@ -439,7 +439,7 @@ kernel void reduce_artifacts_tile_border(texture2d<float, access::read_write> ou
             norm_cosine = (0.5f-0.5f*cos(-angle*(dx+0.5f)))*(0.5f-0.5f*cos(-angle*(dy+0.5f)));
             
             // extract RGBA pixel values
-            pixel_value = output_texture.read(uint2(x, y));
+            pixel_value = out_texture.read(uint2(x, y));
             // clamp values, which reduces potential artifacts (black lines) at tile borders by removing pixels with negative entries (negative when black level is subtracted)
             pixel_value = clamp(pixel_value, norm_cosine*min_values, max_values);
             
@@ -449,7 +449,7 @@ kernel void reduce_artifacts_tile_border(texture2d<float, access::read_write> ou
                 pixel_value = 0.5f*(norm_cosine*ref_texture.read(uint2(x, y)) + pixel_value);
             }
              
-            output_texture.write(pixel_value, uint2(x, y));
+            out_texture.write(pixel_value, uint2(x, y));
         }
     }
 }

--- a/burstphoto/merge/frequency.swift
+++ b/burstphoto/merge/frequency.swift
@@ -343,7 +343,7 @@ func backward_ft(_ in_texture_ft: MTLTexture, _ tile_info: TileInfo, _ n_texture
     out_texture_descriptor.usage = [.shaderRead, .shaderWrite]
     out_texture_descriptor.storageMode = .private
     let out_texture = device.makeTexture(descriptor: out_texture_descriptor)!
-    out_texture.label = "\(in_texture_ft.label!.components(separatedBy: ":")[0]): BT"
+    out_texture.label = "\(in_texture_ft.label!.components(separatedBy: ":")[0]): BT Image"
     
     let command_buffer = command_queue.makeCommandBuffer()!
     command_buffer.label = "Backward FT"
@@ -371,7 +371,7 @@ func forward_ft(_ in_texture: MTLTexture, _ tile_info: TileInfo) -> MTLTexture {
     out_texture_ft_descriptor.usage = [.shaderRead, .shaderWrite]
     out_texture_ft_descriptor.storageMode = .private
     let out_texture_ft = device.makeTexture(descriptor: out_texture_ft_descriptor)!
-    out_texture_ft.label = "\(in_texture.label!.components(separatedBy: ":")[0]): FT"
+    out_texture_ft.label = "\(in_texture.label!.components(separatedBy: ":")[0]): FT Image"
 
     let command_buffer = command_queue.makeCommandBuffer()!
     command_buffer.label = "Forward FT"

--- a/burstphoto/merge/frequency.swift
+++ b/burstphoto/merge/frequency.swift
@@ -239,6 +239,7 @@ func calculate_highlights_norm_rgba(_ aligned_texture: MTLTexture, _ exposure_fa
     highlights_norm_texture_descriptor.usage = [.shaderRead, .shaderWrite]
     highlights_norm_texture_descriptor.storageMode = .private
     let highlights_norm_texture = device.makeTexture(descriptor: highlights_norm_texture_descriptor)!
+    highlights_norm_texture.label = "\(aligned_texture.label!.components(separatedBy: ":")[0]): Highlight Norm"
     
     let command_buffer = command_queue.makeCommandBuffer()!
     command_buffer.label = "Highlights Norm"
@@ -268,6 +269,7 @@ func calculate_mismatch_rgba(_ aligned_texture: MTLTexture, _ ref_texture: MTLTe
     mismatch_texture_descriptor.usage = [.shaderRead, .shaderWrite]
     mismatch_texture_descriptor.storageMode = .private
     let mismatch_texture = device.makeTexture(descriptor: mismatch_texture_descriptor)!
+    mismatch_texture.label = "\(aligned_texture.label!.components(separatedBy: ":")[0]): Mismatch"
     
     let abs_diff_texture = calculate_abs_diff_rgba(ref_texture, aligned_texture)
     
@@ -297,6 +299,7 @@ func calculate_rms_rgba(_ in_texture: MTLTexture, _ tile_info: TileInfo) -> MTLT
     rms_texture_descriptor.usage = [.shaderRead, .shaderWrite]
     rms_texture_descriptor.storageMode = .private
     let rms_texture = device.makeTexture(descriptor: rms_texture_descriptor)!
+    rms_texture.label = "\(in_texture.label!.components(separatedBy: ":")[0]): RMS"
     
     let command_buffer = command_queue.makeCommandBuffer()!
     command_buffer.label = "RMS RGBA"
@@ -340,6 +343,7 @@ func backward_ft(_ in_texture_ft: MTLTexture, _ tile_info: TileInfo, _ n_texture
     out_texture_descriptor.usage = [.shaderRead, .shaderWrite]
     out_texture_descriptor.storageMode = .private
     let out_texture = device.makeTexture(descriptor: out_texture_descriptor)!
+    out_texture.label = "\(in_texture_ft.label!.components(separatedBy: ":")[0]): BT"
     
     let command_buffer = command_queue.makeCommandBuffer()!
     command_buffer.label = "Backward FT"
@@ -367,6 +371,7 @@ func forward_ft(_ in_texture: MTLTexture, _ tile_info: TileInfo) -> MTLTexture {
     out_texture_ft_descriptor.usage = [.shaderRead, .shaderWrite]
     out_texture_ft_descriptor.storageMode = .private
     let out_texture_ft = device.makeTexture(descriptor: out_texture_ft_descriptor)!
+    out_texture_ft.label = "\(in_texture.label!.components(separatedBy: ":")[0]): FT"
 
     let command_buffer = command_queue.makeCommandBuffer()!
     command_buffer.label = "Forward FT"
@@ -429,10 +434,9 @@ func normalize_mismatch(_ mismatch_texture: MTLTexture, _ mean_mismatch_buffer: 
 }
 
 
-func reduce_artifacts_tile_border(_ output_texture: MTLTexture, _ ref_texture: MTLTexture, _ tile_info: TileInfo, _ black_level: [Int]) {
+func reduce_artifacts_tile_border(_ out_texture: MTLTexture, _ ref_texture: MTLTexture, _ tile_info: TileInfo, _ black_level: [Int]) {
         
     if (black_level[0] != -1) {
-        
         let command_buffer = command_queue.makeCommandBuffer()!
         command_buffer.label = "Reduce Artifacts at Tile Border"
         let command_encoder = command_buffer.makeComputeCommandEncoder()!
@@ -440,7 +444,7 @@ func reduce_artifacts_tile_border(_ output_texture: MTLTexture, _ ref_texture: M
         command_encoder.setComputePipelineState(state)
         let threads_per_grid = MTLSize(width: tile_info.n_tiles_x, height: tile_info.n_tiles_y, depth: 1)
         let threads_per_thread_group = get_threads_per_thread_group(state, threads_per_grid)
-        command_encoder.setTexture(output_texture, index: 0)
+        command_encoder.setTexture(out_texture, index: 0)
         command_encoder.setTexture(ref_texture, index: 1)
         command_encoder.setBytes([Int32(tile_info.tile_size_merge)], length: MemoryLayout<Int32>.stride, index: 0)
         command_encoder.setBytes([Int32(black_level[0])], length: MemoryLayout<Int32>.stride, index: 1)

--- a/burstphoto/merge/spatial.swift
+++ b/burstphoto/merge/spatial.swift
@@ -108,6 +108,7 @@ func color_difference(between texture1: MTLTexture, and texture2: MTLTexture, mo
     out_texture_descriptor.usage = [.shaderRead, .shaderWrite]
     out_texture_descriptor.storageMode = .private
     let output_texture = device.makeTexture(descriptor: out_texture_descriptor)!
+    output_texture.label = "\(texture1.label!.components(separatedBy: ":")[0]): Color Difference"
     
     // compute pixel pairwise differences
     let command_buffer = command_queue.makeCommandBuffer()!
@@ -154,6 +155,7 @@ func robust_merge(_ ref_texture: MTLTexture, _ ref_texture_blurred: MTLTexture, 
     weight_texture_descriptor.usage = [.shaderRead, .shaderWrite]
     weight_texture_descriptor.storageMode = .private
     let weight_texture = device.makeTexture(descriptor: weight_texture_descriptor)!
+    weight_texture.label = "\(comp_texture.label!.components(separatedBy: ":")[0]): Weight Texture"
     
     // compute merge weight
     let command_buffer = command_queue.makeCommandBuffer()!
@@ -175,8 +177,8 @@ func robust_merge(_ ref_texture: MTLTexture, _ ref_texture_blurred: MTLTexture, 
     let weight_texture_upsampled = upsample(weight_texture, to_width: ref_texture.width, to_height: ref_texture.height, using: .Bilinear)
     
     // average the input textures based on the weight
-    let output_texture = add_texture_weighted(ref_texture, comp_texture, weight_texture_upsampled)
+    let merged_texture = add_texture_weighted(ref_texture, comp_texture, weight_texture_upsampled)
     
-    return output_texture
+    return merged_texture
 }
 

--- a/burstphoto/texture/texture.swift
+++ b/burstphoto/texture/texture.swift
@@ -121,6 +121,7 @@ func add_texture_weighted(_ texture1: MTLTexture, _ texture2: MTLTexture, _ weig
     out_texture_descriptor.usage = [.shaderRead, .shaderWrite]
     out_texture_descriptor.storageMode = .private
     let out_texture = device.makeTexture(descriptor: out_texture_descriptor)!
+    out_texture.label = texture1.label
     
     // add textures
     let command_buffer = command_queue.makeCommandBuffer()!
@@ -143,8 +144,10 @@ func add_texture_weighted(_ texture1: MTLTexture, _ texture2: MTLTexture, _ weig
 
 
 func blur(_ in_texture: MTLTexture, with_pattern_width mosaic_pattern_width: Int, using_kernel_size kernel_size: Int) -> MTLTexture {
-    let blurred_in_x_texture = texture_like(in_texture)
+    let blurred_in_x_texture  = texture_like(in_texture)
     let blurred_in_xy_texture = texture_like(in_texture)
+    blurred_in_x_texture.label  = "\(in_texture.label!.components(separatedBy: ":")[0]): blurred in x by \(kernel_size)"
+    blurred_in_xy_texture.label = "\(in_texture.label!.components(separatedBy: ":")[0]): blurred by \(kernel_size)"
     
     let kernel_size_mapped = (kernel_size == 16) ? 16 : max(0, min(8, kernel_size))
     
@@ -201,6 +204,9 @@ func calculate_black_levels(for texture: MTLTexture, from_masked_areas masked_ar
         texture_descriptor.usage = [.shaderRead, .shaderWrite]
         texture_descriptor.storageMode = .private
         let summed_y = device.makeTexture(descriptor: texture_descriptor)!
+        summed_y.label = "\(texture.label!.components(separatedBy: ":")[0]): Summed in y for black level"
+        
+        
         
         // Sum along columns
         let command_buffer = command_queue.makeCommandBuffer()!
@@ -222,6 +228,7 @@ func calculate_black_levels(for texture: MTLTexture, from_masked_areas masked_ar
         // Sum along the row
         let sum_buffer = device.makeBuffer(length: (mosaic_pattern_width*mosaic_pattern_width)*MemoryLayout<Float32>.size,
                                            options: .storageModeShared)!
+        sum_buffer.label = "\(texture.label!.components(separatedBy: ":")[0]): Black Levels from masked area \(i)"
         command_encoder.setComputePipelineState(sum_row_state)
         command_encoder.setTexture(summed_y, index: 0)
         command_encoder.setBuffer(sum_buffer, offset: 0, index: 0)
@@ -260,6 +267,7 @@ func calculate_weight_highlights(_ in_texture: MTLTexture, _ exposure_bias: Int,
     weight_highlights_texture_descriptor.usage = [.shaderRead, .shaderWrite]
     weight_highlights_texture_descriptor.storageMode = .private
     let weight_highlights_texture = device.makeTexture(descriptor: weight_highlights_texture_descriptor)!
+    weight_highlights_texture.label = "\(in_texture.label!.components(separatedBy: ":")[0]): Weight Highlights"
   
     let kernel_size = 4
     
@@ -292,6 +300,7 @@ func convert_float_to_uint16(_ in_texture: MTLTexture, _ white_level: Int, _ bla
     let out_texture_descriptor = MTLTextureDescriptor.texture2DDescriptor(pixelFormat: .r16Uint, width: in_texture.width, height: in_texture.height, mipmapped: false)
     out_texture_descriptor.usage = [.shaderRead, .shaderWrite]
     let out_texture = device.makeTexture(descriptor: out_texture_descriptor)!
+    out_texture.label = "\(in_texture.label!.components(separatedBy: ":")[0]): UInt16"
     
     let command_buffer = command_queue.makeCommandBuffer()!
     command_buffer.label = "Float to UInt"
@@ -322,6 +331,7 @@ func convert_to_rgba(_ in_texture: MTLTexture, _ crop_x: Int, _ crop_y: Int) -> 
     out_texture_descriptor.usage = [.shaderRead, .shaderWrite]
     out_texture_descriptor.storageMode = .private
     let out_texture = device.makeTexture(descriptor: out_texture_descriptor)!
+    out_texture.label = "\(in_texture.label!.components(separatedBy: ":")[0]): RGBA from Bayer"
         
     let command_buffer = command_queue.makeCommandBuffer()!
     command_buffer.label = "To RGBA"
@@ -348,6 +358,7 @@ func convert_to_bayer(_ in_texture: MTLTexture, _ pad_left: Int, _ pad_right: In
     out_texture_descriptor.usage = [.shaderRead, .shaderWrite]
     out_texture_descriptor.storageMode = .private
     let out_texture = device.makeTexture(descriptor: out_texture_descriptor)!
+    out_texture.label = "\(in_texture.label!.components(separatedBy: ":")[0]): RGBA from Bayer"
         
     let command_buffer = command_queue.makeCommandBuffer()!
     command_buffer.label = "To Bayer"
@@ -375,6 +386,7 @@ func copy_texture(_ in_texture: MTLTexture) -> MTLTexture {
     out_texture_descriptor.usage = [.shaderRead, .shaderWrite]
     out_texture_descriptor.storageMode = .private
     let out_texture = device.makeTexture(descriptor: out_texture_descriptor)!
+    out_texture.label = in_texture.label
     
     let command_buffer = command_queue.makeCommandBuffer()!
     command_buffer.label = "Copy Texture"
@@ -399,6 +411,7 @@ func crop_texture(_ in_texture: MTLTexture, _ pad_left: Int, _ pad_right: Int, _
     out_texture_descriptor.usage = [.shaderRead, .shaderWrite]
     out_texture_descriptor.storageMode = .private
     let out_texture = device.makeTexture(descriptor: out_texture_descriptor)!
+    out_texture.label = in_texture.label
     
     let command_buffer = command_queue.makeCommandBuffer()!
     command_buffer.label = "Crop Texture"
@@ -457,6 +470,7 @@ func find_hotpixels(_ textures: [MTLTexture], _ hotpixel_weight_texture: MTLText
         average_texture_descriptor.usage = [.shaderRead, .shaderWrite]
         average_texture_descriptor.storageMode = .private
         let average_texture = device.makeTexture(descriptor: average_texture_descriptor)!
+        average_texture.label = "Average of all texture"
         fill_with_zeros(average_texture)
         
         // iterate over all images
@@ -580,11 +594,16 @@ func normalize_texture(_ in_texture: MTLTexture, _ norm_texture: MTLTexture, _ n
 /// Inspired by https://ai.googleblog.com/2021/04/hdr-with-bracketing-on-pixel-phones.html
 func prepare_texture(_ in_texture: MTLTexture, _ hotpixel_weight_texture: MTLTexture, _ pad_left: Int, _ pad_right: Int, _ pad_top: Int, _ pad_bottom: Int, _ exposure_diff: Int, _ black_level: [[Int]], _ comp_idx: Int) -> MTLTexture {
 
-    // always use pixel format float32 with increased precision that merging is performed with best possible precision
-    let out_texture_descriptor = MTLTextureDescriptor.texture2DDescriptor(pixelFormat: .r32Float, width: in_texture.width+pad_left+pad_right, height: in_texture.height+pad_top+pad_bottom, mipmapped: false)
+    // always use pixel format float32 with increased precision that merging is performed with best possible precision    
+    let out_texture_descriptor = MTLTextureDescriptor.texture2DDescriptor(pixelFormat: .r16Float,
+                                                                          width: in_texture.width+pad_left+pad_right,
+                                                                          height: in_texture.height+pad_top+pad_bottom,
+                                                                          mipmapped: false)
     out_texture_descriptor.usage = [.shaderRead, .shaderWrite]
     out_texture_descriptor.storageMode = .private
     let out_texture = device.makeTexture(descriptor: out_texture_descriptor)!
+    out_texture.label = "\(in_texture.label!.components(separatedBy: ":")[0]): Extended"
+    
     fill_with_zeros(out_texture)
         
     let command_buffer = command_queue.makeCommandBuffer()!
@@ -613,12 +632,14 @@ func prepare_texture(_ in_texture: MTLTexture, _ hotpixel_weight_texture: MTLTex
 
 
 /// Create and return a new texture that has the same properties as the one passed in.
-func texture_like(_ input_texture: MTLTexture) -> MTLTexture {
-    let output_texture_descriptor = MTLTextureDescriptor.texture2DDescriptor(pixelFormat: input_texture.pixelFormat, width: input_texture.width, height: input_texture.height, mipmapped: false)
-    output_texture_descriptor.usage = [.shaderRead, .shaderWrite]
-    output_texture_descriptor.storageMode = .private
-    let output_texture = device.makeTexture(descriptor: output_texture_descriptor)!
-    return output_texture
+func texture_like(_ in_texture: MTLTexture) -> MTLTexture {
+    let out_texture_descriptor = MTLTextureDescriptor.texture2DDescriptor(pixelFormat: in_texture.pixelFormat, width: in_texture.width, height: in_texture.height, mipmapped: false)
+    out_texture_descriptor.usage = [.shaderRead, .shaderWrite]
+    out_texture_descriptor.storageMode = .private
+    let out_texture = device.makeTexture(descriptor: out_texture_descriptor)!
+    out_texture.label = in_texture.label
+    
+    return out_texture
 }
 
 
@@ -663,7 +684,7 @@ func texture_mean(_ in_texture: MTLTexture, _ pixelformat: PixelFormat) -> MTLBu
 
 /// Upsample the provided texture to the specified widths using either a nearest neighbour approach or using bilinear interpolation.
 func upsample(_ input_texture: MTLTexture, to_width width: Int, to_height height: Int, using mode: UpsampleType) -> MTLTexture {
-    let scale_x = Double(width) / Double(input_texture.width)
+    let scale_x = Double(width)  / Double(input_texture.width)
     let scale_y = Double(height) / Double(input_texture.height)
     
     // create output texture
@@ -671,6 +692,7 @@ func upsample(_ input_texture: MTLTexture, to_width width: Int, to_height height
     output_texture_descriptor.usage = [.shaderRead, .shaderWrite]
     output_texture_descriptor.storageMode = .private
     let output_texture = device.makeTexture(descriptor: output_texture_descriptor)!
+    output_texture.label = input_texture.label
     
     let command_buffer = command_queue.makeCommandBuffer()!
     command_buffer.label = "Upsample"
@@ -679,7 +701,7 @@ func upsample(_ input_texture: MTLTexture, to_width width: Int, to_height height
     command_encoder.setComputePipelineState(state)
     let threads_per_grid = MTLSize(width: output_texture.width, height: output_texture.height, depth: 1)
     let threads_per_thread_group = get_threads_per_thread_group(state, threads_per_grid)
-    command_encoder.setTexture(input_texture, index: 0)
+    command_encoder.setTexture(input_texture,  index: 0)
     command_encoder.setTexture(output_texture, index: 1)
     command_encoder.setBytes([Float32(scale_x)], length: MemoryLayout<Float32>.stride, index: 0)
     command_encoder.setBytes([Float32(scale_y)], length: MemoryLayout<Float32>.stride, index: 1)

--- a/burstphoto/texture/texture.swift
+++ b/burstphoto/texture/texture.swift
@@ -331,7 +331,7 @@ func convert_to_rgba(_ in_texture: MTLTexture, _ crop_x: Int, _ crop_y: Int) -> 
     out_texture_descriptor.usage = [.shaderRead, .shaderWrite]
     out_texture_descriptor.storageMode = .private
     let out_texture = device.makeTexture(descriptor: out_texture_descriptor)!
-    out_texture.label = "\(in_texture.label!.components(separatedBy: ":")[0]): RGBA from Bayer"
+    out_texture.label = "\(in_texture.label!.components(separatedBy: ":")[0]): Bayer to RGBA"
         
     let command_buffer = command_queue.makeCommandBuffer()!
     command_buffer.label = "To RGBA"
@@ -358,7 +358,7 @@ func convert_to_bayer(_ in_texture: MTLTexture, _ pad_left: Int, _ pad_right: In
     out_texture_descriptor.usage = [.shaderRead, .shaderWrite]
     out_texture_descriptor.storageMode = .private
     let out_texture = device.makeTexture(descriptor: out_texture_descriptor)!
-    out_texture.label = "\(in_texture.label!.components(separatedBy: ":")[0]): RGBA from Bayer"
+    out_texture.label = "\(in_texture.label!.components(separatedBy: ":")[0]): RGBA to Bayer"
         
     let command_buffer = command_queue.makeCommandBuffer()!
     command_buffer.label = "To Bayer"
@@ -595,14 +595,11 @@ func normalize_texture(_ in_texture: MTLTexture, _ norm_texture: MTLTexture, _ n
 func prepare_texture(_ in_texture: MTLTexture, _ hotpixel_weight_texture: MTLTexture, _ pad_left: Int, _ pad_right: Int, _ pad_top: Int, _ pad_bottom: Int, _ exposure_diff: Int, _ black_level: [[Int]], _ comp_idx: Int) -> MTLTexture {
 
     // always use pixel format float32 with increased precision that merging is performed with best possible precision    
-    let out_texture_descriptor = MTLTextureDescriptor.texture2DDescriptor(pixelFormat: .r16Float,
-                                                                          width: in_texture.width+pad_left+pad_right,
-                                                                          height: in_texture.height+pad_top+pad_bottom,
-                                                                          mipmapped: false)
+    let out_texture_descriptor = MTLTextureDescriptor.texture2DDescriptor(pixelFormat: .r32Float, width: in_texture.width+pad_left+pad_right, height: in_texture.height+pad_top+pad_bottom, mipmapped: false)
     out_texture_descriptor.usage = [.shaderRead, .shaderWrite]
     out_texture_descriptor.storageMode = .private
     let out_texture = device.makeTexture(descriptor: out_texture_descriptor)!
-    out_texture.label = "\(in_texture.label!.components(separatedBy: ":")[0]): Extended"
+    out_texture.label = "\(in_texture.label!.components(separatedBy: ":")[0]): Prepared"
     
     fill_with_zeros(out_texture)
         


### PR DESCRIPTION
Labeling the textures makes it easier to track down individual functions and kernels when capturing metal buffers for debugging purposes.