### PR TITLE
Change float_to_uint16 to work for all mosaic sizes

### DIFF
--- a/burstphoto/denoise.swift
+++ b/burstphoto/denoise.swift
@@ -238,7 +238,7 @@ func perform_denoising(image_urls: [URL], progress: ProcessingProgress, merging_
     let factor_16bit = (scale_to_16bit ? Int(pow(2.0, 16.0-ceil(log2(Double(white_level[ref_idx]))))+0.5) : 1)
 
     // convert final image to 16 bit integer
-    let output_texture_uint16 = convert_float_to_uint16(final_texture, (white_level[ref_idx] == -1 ? 1000000 : factor_16bit*white_level[ref_idx]), black_level[ref_idx], factor_16bit)
+    let output_texture_uint16 = convert_float_to_uint16(final_texture, (white_level[ref_idx] == -1 ? 1000000 : factor_16bit*white_level[ref_idx]), black_level[ref_idx], factor_16bit, mosaic_pattern_width)
       
     print("Time to align+merge all images: ", Float(DispatchTime.now().uptimeNanoseconds - t) / 1_000_000_000)
     t = DispatchTime.now().uptimeNanoseconds

--- a/burstphoto/texture/texture.metal
+++ b/burstphoto/texture/texture.metal
@@ -355,7 +355,7 @@ kernel void convert_float_to_uint16(texture2d<float, access::read>  in_texture  
     float const black_level = black_levels[(gid.x % mosaic_pattern_width) + mosaic_pattern_width * (gid.y % mosaic_pattern_width)];
 
     // apply potential scaling to 16 bit and convert to integer
-    int out_value = int(factor_16bit*round((in_texture.read(gid).r - black_level) + black_level));
+    int out_value = int(round(factor_16bit*(in_texture.read(gid).r - black_level) + black_level));
     out_value     = clamp(out_value, 0, min(white_level, int(UINT16_MAX_VAL)));
     
     // write back into texture

--- a/burstphoto/texture/texture.metal
+++ b/burstphoto/texture/texture.metal
@@ -344,36 +344,22 @@ kernel void calculate_weight_highlights(texture2d<float, access::read> in_textur
 }
 
 
-kernel void convert_float_to_uint16(texture2d<float, access::read> in_texture [[texture(0)]],
-                                    texture2d<uint, access::write> out_texture [[texture(1)]],
-                                    constant int& white_level [[buffer(0)]],
-                                    constant int& black_level0 [[buffer(1)]],
-                                    constant int& black_level1 [[buffer(2)]],
-                                    constant int& black_level2 [[buffer(3)]],
-                                    constant int& black_level3 [[buffer(4)]],
-                                    constant int& factor_16bit [[buffer(5)]],
+kernel void convert_float_to_uint16(texture2d<float, access::read>  in_texture  [[texture(0)]],
+                                    texture2d<uint,  access::write> out_texture [[texture(1)]],
+                                    constant int& white_level           [[buffer(0)]],
+                                    constant int& factor_16bit          [[buffer(1)]],
+                                    constant int& mosaic_pattern_width  [[buffer(2)]],
+                                    constant int* black_levels          [[buffer(3)]],
                                     uint2 gid [[thread_position_in_grid]]) {
-    int const x = gid.x*2;
-    int const y = gid.y*2;
-    
     // load args
-    float4 const black_level = float4(black_level0, black_level1, black_level2, black_level3);
-    
-    // extract pixel values of 2x2 super pixel
-    float4 const pixel_value = float4(in_texture.read(uint2(x,   y)).r,
-                                      in_texture.read(uint2(x+1, y)).r,
-                                      in_texture.read(uint2(x,   y+1)).r,
-                                      in_texture.read(uint2(x+1, y+1)).r);
-    
+    float const black_level = black_levels[(gid.x % mosaic_pattern_width) + mosaic_pattern_width * (gid.y % mosaic_pattern_width)];
+
     // apply potential scaling to 16 bit and convert to integer
-    int4 out_value = int4(round((pixel_value - black_level)*factor_16bit + black_level));
-    out_value = clamp(out_value, 0, min(white_level, int(UINT16_MAX_VAL)));
+    int out_value = int(factor_16bit*round((in_texture.read(gid).r - black_level) + black_level));
+    out_value     = clamp(out_value, 0, min(white_level, int(UINT16_MAX_VAL)));
     
     // write back into texture
-    out_texture.write(uint(out_value[0]), uint2(x,   y));
-    out_texture.write(uint(out_value[1]), uint2(x+1, y));
-    out_texture.write(uint(out_value[2]), uint2(x,   y+1));
-    out_texture.write(uint(out_value[3]), uint2(x+1, y+1));
+    out_texture.write(uint(out_value), gid);
 }
 
 

--- a/burstphoto/texture/texture.swift
+++ b/burstphoto/texture/texture.swift
@@ -301,7 +301,7 @@ func convert_float_to_uint16(_ in_texture: MTLTexture, _ white_level: Int, _ bla
     let command_encoder = command_buffer.makeComputeCommandEncoder()!
     let state = convert_float_to_uint16_state
     command_encoder.setComputePipelineState(state)
-    let threads_per_grid = MTLSize(width: out_texture.width/2, height: out_texture.height/2, depth: 1)
+    let threads_per_grid = MTLSize(width: out_texture.width, height: out_texture.height, depth: 1)
     let threads_per_thread_group = get_threads_per_thread_group(state, threads_per_grid)
     command_encoder.setTexture(in_texture, index: 0)
     command_encoder.setTexture(out_texture, index: 1)

--- a/burstphoto/texture/texture.swift
+++ b/burstphoto/texture/texture.swift
@@ -287,11 +287,14 @@ func calculate_weight_highlights(_ in_texture: MTLTexture, _ exposure_bias: Int,
 
 
 /// Convert a texture of floats into 16 bit uints for storing in a DNG file.
-func convert_float_to_uint16(_ in_texture: MTLTexture, _ white_level: Int, _ black_level: [Int], _ factor_16bit: Int) -> MTLTexture {
+func convert_float_to_uint16(_ in_texture: MTLTexture, _ white_level: Int, _ black_level: [Int], _ factor_16bit: Int, _ mosaic_pattern_width: Int) -> MTLTexture {
     
     let out_texture_descriptor = MTLTextureDescriptor.texture2DDescriptor(pixelFormat: .r16Uint, width: in_texture.width, height: in_texture.height, mipmapped: false)
     out_texture_descriptor.usage = [.shaderRead, .shaderWrite]
     let out_texture = device.makeTexture(descriptor: out_texture_descriptor)!
+    
+    let black_levels_buffer = device.makeBuffer(bytes: black_level.map{Int32($0)},
+                                                length: MemoryLayout<Int32>.size * black_level.count)!
     
     let command_buffer = command_queue.makeCommandBuffer()!
     command_buffer.label = "Float to UInt"
@@ -303,11 +306,10 @@ func convert_float_to_uint16(_ in_texture: MTLTexture, _ white_level: Int, _ bla
     command_encoder.setTexture(in_texture, index: 0)
     command_encoder.setTexture(out_texture, index: 1)
     command_encoder.setBytes([Int32(white_level)], length: MemoryLayout<Int32>.stride, index: 0)
-    command_encoder.setBytes([Int32(black_level[0])], length: MemoryLayout<Int32>.stride, index: 1)
-    command_encoder.setBytes([Int32(black_level[1])], length: MemoryLayout<Int32>.stride, index: 2)
-    command_encoder.setBytes([Int32(black_level[2])], length: MemoryLayout<Int32>.stride, index: 3)
-    command_encoder.setBytes([Int32(black_level[3])], length: MemoryLayout<Int32>.stride, index: 4)
-    command_encoder.setBytes([Int32(factor_16bit)], length: MemoryLayout<Int32>.stride, index: 5)
+    command_encoder.setBytes([Int32(factor_16bit)], length: MemoryLayout<Int32>.stride, index: 1)
+    command_encoder.setBytes([Int32(mosaic_pattern_width)], length: MemoryLayout<Int32>.stride, index: 2)
+    command_encoder.setBuffer(black_levels_buffer, offset: 0, index: 3)
+    
     command_encoder.dispatchThreads(threads_per_grid, threadsPerThreadgroup: threads_per_thread_group)
     command_encoder.endEncoding()
     command_buffer.commit()


### PR DESCRIPTION
Removed the hardcoded Bayer information.

This does **not** enable support for 16-bit output for X-Trans. That also requires support for exposure compensation, and that will be added in a future PR. This PR only needs to be tested for Bayer images.