### PR TITLE
Hotpixel correction for X-Trans

### DIFF
--- a/burstphoto/denoise.swift
+++ b/burstphoto/denoise.swift
@@ -207,10 +207,8 @@ func perform_denoising(image_urls: [URL], progress: ProcessingProgress, merging_
         let hotpixel_weight_texture = device.makeTexture(descriptor: hotpixel_weight_texture_descriptor)!
         hotpixel_weight_texture.label = "Hotpixel weight texture"
         fill_with_zeros(hotpixel_weight_texture)
-                
-        if mosaic_pattern_width == 2 {
-            find_hotpixels(textures, hotpixel_weight_texture, black_level, ISO_exposure_time, noise_reduction, mosaic_pattern_width)
-        }
+        
+        find_hotpixels(textures, hotpixel_weight_texture, black_level, ISO_exposure_time, noise_reduction, mosaic_pattern_width)
         
         if noise_reduction == 23.0 {
             try calculate_temporal_average(progress: progress, mosaic_pattern_width: mosaic_pattern_width, exposure_bias: exposure_bias, white_level: white_level[ref_idx], black_level: black_level, uniform_exposure: uniform_exposure, color_factors: color_factors, textures: textures, hotpixel_weight_texture: hotpixel_weight_texture, final_texture: final_texture)

--- a/burstphoto/denoise.swift
+++ b/burstphoto/denoise.swift
@@ -120,42 +120,34 @@ func perform_denoising(image_urls: [URL], progress: ProcessingProgress, merging_
     t = DispatchTime.now().uptimeNanoseconds
     DispatchQueue.main.async { progress.int += (convert_to_dng ? 10_000_000 : 20_000_000) }
     
-    // if images have a uniform exposure: use central image as reference
-    var ref_idx = image_urls.count / 2
-    var uniform_exposure = true
+    var uniform_exposure = !exposure_bias.contains{$0 != exposure_bias[0]}
     
-    for comp_idx in 0..<image_urls.count {
-        // if images have different exposures: use image with lowest exposure as reference to protect highlights
+    var ref_idx: Int
+    if !uniform_exposure {
+        // Use image with lowest exposure as reference to protect highlights
         // inspired by https://ai.googleblog.com/2021/04/hdr-with-bracketing-on-pixel-phones.html
-        if exposure_bias[comp_idx] < exposure_bias[ref_idx] {
-            ref_idx = comp_idx
-        }
-        // check if exposure is uniform or bracketed
-        if exposure_bias[comp_idx] != exposure_bias[0] {
-            uniform_exposure = false
-        }
-    }
-    
-    // repeat check of uniform exposure, but this time use product of ISO value and exposure time for evaluation
-    if uniform_exposure {
-        for comp_idx in 0..<image_urls.count {
-            // if images have different exposures: use image with lowest exposure as reference to protect highlights
-            if (ISO_exposure_time[ref_idx]-ISO_exposure_time[comp_idx] > 1e-12) {
-                ref_idx = comp_idx
-            }
-            // check if exposure is uniform or bracketed
-            if (abs(ISO_exposure_time[comp_idx]-ISO_exposure_time[0]) > 1e-12) {
-                uniform_exposure = false
-            }
-        }
-        // if exposure bracketing is detected, overwrite exposure bias vector and set darkest frame to exposure bias -2EV
-        if !uniform_exposure {
+        ref_idx = exposure_bias.firstIndex(of: exposure_bias.min()!)!
+    } else {
+        // If a uniform exposure was detected it could be for two reasons:
+        //  1. An actual uniform exposure burst
+        //  2. A burst where ISO or exposure time were changed manually and not through an exposure compensation adjustment
+        
+        // Checking for case 2
+        uniform_exposure = !ISO_exposure_time.contains{abs($0 - ISO_exposure_time[0]) > 1e-12} // 1e-12 is used as a small eps
+        
+        if uniform_exposure { // Case 1: Actually uniform exposure
+            // Use central image in the burst as reference
+            // This is based on the assumption that in a burst, the central image will be the most closest image to all other images.
+            ref_idx = image_urls.count / 2
+        } else { // Case 2: Non-uniform exposure, need to chance ref_idx and exposure_bias values
+            ref_idx = ISO_exposure_time.firstIndex(of: ISO_exposure_time.min()!)!
+            
+            // Overwrite exposure bias values and set darkest frame to an exposure bias of -2EV
             for comp_idx in 0..<image_urls.count {
                 exposure_bias[comp_idx] = Int(round((log2(ISO_exposure_time[comp_idx]/ISO_exposure_time[ref_idx])-2.0)*100))
             }
         }
     }
-    
     // check for non-Bayer sensors that the exposure of images is uniform
     if (!uniform_exposure && mosaic_pattern_width != 2) {throw AlignmentError.non_bayer_exposure_bracketing}
     

--- a/burstphoto/denoise.swift
+++ b/burstphoto/denoise.swift
@@ -338,7 +338,7 @@ func calculate_temporal_average(progress: ProcessingProgress, mosaic_pattern_wid
         
         // 1. add up all frames of the burst
         for comp_idx in 0..<textures.count {
-            let comp_texture = prepare_texture(textures[comp_idx], hotpixel_weight_texture, 0, 0, 0, 0, exposure_bias[exp_idx]-exposure_bias[comp_idx], black_level, comp_idx)
+            let comp_texture = prepare_texture(textures[comp_idx], hotpixel_weight_texture, 0, 0, 0, 0, exposure_bias[exp_idx]-exposure_bias[comp_idx], black_level[comp_idx], mosaic_pattern_width)
                        
             if exposure_bias[comp_idx] == exposure_bias[exp_idx] {
                 add_texture_highlights(comp_texture, final_texture, white_level, black_level[comp_idx], color_factors[comp_idx])
@@ -356,7 +356,7 @@ func calculate_temporal_average(progress: ProcessingProgress, mosaic_pattern_wid
         
         // simple temporal averaging
         for comp_idx in 0..<textures.count {
-            let comp_texture = prepare_texture(textures[comp_idx], hotpixel_weight_texture, 0, 0, 0, 0, 0, black_level, comp_idx)
+            let comp_texture = prepare_texture(textures[comp_idx], hotpixel_weight_texture, 0, 0, 0, 0, 0, black_level[comp_idx], mosaic_pattern_width)
             add_texture(comp_texture, final_texture, textures.count)
             DispatchQueue.main.async { progress.int += Int(80_000_000/Double(textures.count)) }
         }

--- a/burstphoto/merge/frequency.swift
+++ b/burstphoto/merge/frequency.swift
@@ -120,7 +120,7 @@ func align_merge_frequency_domain(progress: ProcessingProgress, ref_idx: Int, mo
         let pad_bottom = pad_align_y + shift_bottom
         
         // prepare reference texture by correcting hot pixels, equalizing exposure and extending the texture
-        let ref_texture = prepare_texture(textures[ref_idx], hotpixel_weight_texture, pad_left, pad_right, pad_top, pad_bottom, 0, black_level, ref_idx)
+        let ref_texture = prepare_texture(textures[ref_idx], hotpixel_weight_texture, pad_left, pad_right, pad_top, pad_bottom, 0, black_level[ref_idx], mosaic_pattern_width)
         // convert reference texture into RGBA pixel format that SIMD instructions can be applied
         let ref_texture_rgba = convert_to_rgba(ref_texture, crop_merge_x, crop_merge_y)
         
@@ -149,7 +149,7 @@ func align_merge_frequency_domain(progress: ProcessingProgress, ref_idx: Int, mo
             }
             
             // prepare comparison texture by correcting hot pixels, equalizing exposure and extending the texture
-            let comp_texture = prepare_texture(textures[comp_idx], hotpixel_weight_texture, pad_left, pad_right, pad_top, pad_bottom, (exposure_bias[ref_idx]-exposure_bias[comp_idx]), black_level, comp_idx)
+            let comp_texture = prepare_texture(textures[comp_idx], hotpixel_weight_texture, pad_left, pad_right, pad_top, pad_bottom, (exposure_bias[ref_idx]-exposure_bias[comp_idx]), black_level[comp_idx], mosaic_pattern_width)
             
             black_level_mean = Double(black_level[comp_idx].reduce(0, +)) / Double(black_level[comp_idx].count)
             

--- a/burstphoto/merge/spatial.swift
+++ b/burstphoto/merge/spatial.swift
@@ -51,7 +51,7 @@ func align_merge_spatial_domain(progress: ProcessingProgress, ref_idx: Int, mosa
     pad_align_y = (pad_align_y*Int(tile_factor) - texture_height_orig)/2
     
     // prepare reference texture by correcting hot pixels, equalizing exposure and extending the texture
-    let ref_texture = prepare_texture(textures[ref_idx], hotpixel_weight_texture, pad_align_x, pad_align_x, pad_align_y, pad_align_y, 0, black_level, ref_idx)
+    let ref_texture = prepare_texture(textures[ref_idx], hotpixel_weight_texture, pad_align_x, pad_align_x, pad_align_y, pad_align_y, 0, black_level[ref_idx], mosaic_pattern_width)
     let ref_texture_cropped = crop_texture(ref_texture, pad_align_x, pad_align_x, pad_align_y, pad_align_y)
     
     var black_level_mean = Double(black_level[ref_idx].reduce(0, +)) / Double(black_level[ref_idx].count)
@@ -75,7 +75,7 @@ func align_merge_spatial_domain(progress: ProcessingProgress, ref_idx: Int, mosa
         }
             
         // prepare comparison texture by correcting hot pixels, equalizing exposure and extending the texture
-        let comp_texture = prepare_texture(textures[comp_idx], hotpixel_weight_texture, pad_align_x, pad_align_x, pad_align_y, pad_align_y, (exposure_bias[ref_idx]-exposure_bias[comp_idx]), black_level, comp_idx)
+        let comp_texture = prepare_texture(textures[comp_idx], hotpixel_weight_texture, pad_align_x, pad_align_x, pad_align_y, pad_align_y, (exposure_bias[ref_idx]-exposure_bias[comp_idx]), black_level[comp_idx], mosaic_pattern_width)
          
         black_level_mean = Double(black_level[comp_idx].reduce(0, +)) / Double(black_level[comp_idx].count)
         

--- a/burstphoto/texture/texture.metal
+++ b/burstphoto/texture/texture.metal
@@ -356,41 +356,26 @@ kernel void fill_with_zeros(texture2d<float, access::write> texture [[texture(0)
 
 
 /**
- Hot pixel correction based on the idea that hot pixels appear at the same pixel location in all images
+ Hot pixel identification for Bayer images.
+ Note: A 2-pixel wide border of the image is NOT analyzed in order to make the algorithm simpler.
  */
-kernel void find_hotpixels(texture2d<float, access::read> average_texture [[texture(0)]],
-                           texture2d<float, access::write> hotpixel_weight_texture [[texture(1)]],
-                           constant float* mean_texture_buffer [[buffer(0)]],
-                           constant float& black_level0 [[buffer(1)]],
-                           constant float& black_level1 [[buffer(2)]],
-                           constant float& black_level2 [[buffer(3)]],
-                           constant float& black_level3 [[buffer(4)]],
-                           constant float& hot_pixel_threshold [[buffer(5)]],
-                           constant float& hot_pixel_multiplicator [[buffer(6)]],
-                           constant float& correction_strength [[buffer(7)]],
-                           uint2 gid [[thread_position_in_grid]]) {
-       
+kernel void find_hotpixels_bayer(texture2d<float, access::read>  average_texture         [[texture(0)]],
+                                 texture2d<float, access::write> hotpixel_weight_texture [[texture(1)]],
+                                 constant float* mean_texture_buffer     [[buffer(0)]],
+                                 constant float* black_levels            [[buffer(1)]],
+                                 constant float& hot_pixel_threshold     [[buffer(2)]],
+                                 constant float& hot_pixel_multiplicator [[buffer(3)]],
+                                 constant float& correction_strength     [[buffer(4)]],
+                                 uint2 gid [[thread_position_in_grid]]) {
+    // +2 to offset from top-left edge in order to calculate sum of neighbouring pixels
     int const x = gid.x+2;
     int const y = gid.y+2;
     
-    // load args
-    float mean_texture = 0.0f;
-    float black_level = 0.0f;
-    
     // extract color channel-dependent mean value of the average texture of all images and the black level
-    if (x%2 == 0 & y%2 == 0) {
-        mean_texture = mean_texture_buffer[0] - black_level0;
-        black_level = float(black_level0);
-    } else if (x%2 == 1 & y%2 == 0) {
-        mean_texture = mean_texture_buffer[1] - black_level1;
-        black_level = float(black_level1);
-    } else if (x%2 == 0 & y%2 == 1) {
-        mean_texture = mean_texture_buffer[2] - black_level2;
-        black_level = float(black_level2);
-    } else if (x%2 == 1 & y%2 == 1) {
-        mean_texture = mean_texture_buffer[3] - black_level3;
-        black_level = float(black_level3);
-    }
+    int const ix = x % 2;
+    int const iy = y % 2;
+    float const black_level  = float(black_levels[ix + 2*iy]);
+    float const mean_texture = mean_texture_buffer[ix + 2*iy] - black_level;
         
     // calculate weighted sum of 8 pixels surrounding the potential hot pixel based on the average texture
     float sum =   average_texture.read(uint2(x-2, y-2)).r;
@@ -402,17 +387,126 @@ kernel void find_hotpixels(texture2d<float, access::read> average_texture [[text
     sum      += 2*average_texture.read(uint2(x+0, y-2)).r;
     sum      += 2*average_texture.read(uint2(x+0, y+2)).r;
     
+    sum /= 12.0;
+    
     // extract value of potential hot pixel from the average texture and divide by sum of surrounding pixels
     float const pixel_value = average_texture.read(uint2(x, y)).r;
-    float const pixel_ratio = max(pixel_value-black_level, 1.0f)/max(sum/12.0f-black_level, 1.0f);
+    float const pixel_ratio = max(1.0, 
+                                  pixel_value - black_level) / max(1.0, sum - black_level);
     
     // if hot pixel is detected
     if (pixel_ratio >= hot_pixel_threshold & pixel_value >= 2.0f*mean_texture) {
-        
         // calculate weight for blending to have a smooth transition for not so obvious hot pixels
-        float const weight = correction_strength*0.5f*min(hot_pixel_multiplicator*(pixel_ratio-hot_pixel_threshold), 2.0f);
+        float const weight = 0.5f * correction_strength * min(2.0f,
+                                                              hot_pixel_multiplicator * (pixel_ratio - hot_pixel_threshold));
+        hotpixel_weight_texture.write(weight, uint2(x, y));
+    }
+}
+
+/**
+ Hot pixel identification for X-Trans images
+ Similar idea to Bayer correction except that it requires extra work since the mosaic pattern is so large.
+ The same approach used for the Bayer images would make color artifacts in small regions with high contrast (e.g. white lines on a black surface would gain a strong purple color).
+ Inspired by : https://github.com/darktable-org/darktable/blob/1aca07c62d1c8de7129c93f653bfbf8b4f6a1874/src/iop/hotpixels.c#L231-L343
+ */
+kernel void find_hotpixels_xtrans(texture2d<float, access::read>  average_texture         [[texture(0)]],
+                                  texture2d<float, access::write> hotpixel_weight_texture [[texture(1)]],
+                                  constant float* mean_texture_buffer     [[buffer(0)]],
+                                  constant float* black_levels            [[buffer(1)]],
+                                  constant float& hot_pixel_threshold     [[buffer(2)]],
+                                  constant float& hot_pixel_multiplicator [[buffer(3)]],
+                                  constant float& correction_strength     [[buffer(4)]],
+                                  uint2 gid [[thread_position_in_grid]]) {
+    // A more accurate approach for the R and B would be to average out the two knight positions that have 1 distance between them, but that seems more computationally expensive.
+    // Lookup table for the relative positions of the closest 4 sub-pixels of the same color (🐷 approach)
+    int offset[6][6][4][2] = {
+        { // Row 0
+            {{ 0, -1}, { 1, -1}, { 1,  0}, {-1,  1}}, // G
+            {{ 0, -1}, { 1,  1}, {-1,  0}, {-1, -1}}, // G
+            {{ 1, -2}, { 2,  1}, { 0,  2}, {-2,  1}}, // B
+            {{ 0, -1}, { 1, -1}, { 1,  0}, {-1,  1}}, // G
+            {{ 0, -1}, { 1,  1}, {-1,  0}, {-1, -1}}, // G
+            {{ 1, -2}, { 2,  1}, { 0,  2}, {-2,  1}}  // R
+        },
+        { // Row 1
+            {{-1,  2}, {-2,  0}, {-1, -2}, { 2, -1}}, // B
+            {{ 1, -2}, { 2,  0}, { 1,  2}, {-2,  1}}, // R
+            {{ 1, -1}, { 1,  1}, {-1,  1}, {-1, -1}}, // G
+            {{ 2, -1}, { 2,  1}, {-1,  2}, {-2,  0}}, // R
+            {{ 1, -2}, { 2,  0}, { 1,  2}, {-2,  1}}, // B
+            {{ 1, -1}, { 1,  1}, {-1,  1}, {-1, -1}}  // G
+        },
+        { // Row 2
+            {{ 1,  0}, { 1,  1}, { 0,  1}, {-1,  1}}, // G
+            {{ 1, -1}, { 0,  1}, {-1,  1}, {-1,  0}}, // G
+            {{-2, -1}, { 0, -2}, { 2, -1}, { 1, -2}}, // B
+            {{ 1,  0}, { 1,  1}, { 0,  1}, {-1,  1}}, // G
+            {{ 1, -1}, { 0,  1}, {-1,  1}, {-1,  0}}, // G
+            {{-2, -1}, { 0, -2}, { 2, -1}, { 1, -2}}  // R
+        },
+        { // Row 3
+            {{ 0, -1}, { 1, -1}, { 1,  0}, {-1,  1}}, // G
+            {{ 0, -1}, { 1,  1}, {-1,  0}, {-1, -1}}, // G
+            {{ 1, -2}, { 2,  1}, { 0,  2}, {-2,  1}}, // R
+            {{ 0, -1}, { 1, -1}, { 1,  0}, {-1,  1}}, // G
+            {{ 0, -1}, { 1,  1}, {-1,  0}, {-1, -1}}, // G
+            {{ 1, -2}, { 2,  1}, { 0,  2}, {-2,  1}}  // B
+        },
+        { // Row 4
+            {{-1,  2}, {-2,  0}, {-1, -2}, { 2, -1}}, // R
+            {{ 1, -2}, { 2,  0}, { 1,  2}, {-2,  1}}, // B
+            {{ 1, -1}, { 1,  1}, {-1,  1}, {-1, -1}}, // G
+            {{ 2, -1}, { 2,  1}, {-1,  2}, {-2,  0}}, // B
+            {{ 1, -2}, { 2,  0}, { 1,  2}, {-2,  1}}, // R
+            {{ 1, -1}, { 1,  1}, {-1,  1}, {-1, -1}}  // G
+        },
+        { // Row 5
+            {{ 1,  0}, { 1,  1}, { 0,  1}, {-1,  1}}, // G
+            {{ 1, -1}, { 0,  1}, {-1,  1}, {-1,  0}}, // G
+            {{-2, -1}, { 0, -2}, { 2, -1}, { 1, -2}}, // R
+            {{ 1,  0}, { 1,  1}, { 0,  1}, {-1,  1}}, // G
+            {{ 1, -1}, { 0,  1}, {-1,  1}, {-1,  0}}, // G
+            {{-2, -1}, { 0, -2}, { 2, -1}, { 1, -2}}  // B
+        }
+    };
+    
+    // +2 to offset from top-left edge in order to calculate sum of neighbouring pixels
+    int const x = gid.x+2;
+    int const y = gid.y+2;
+    
+    // extract color channel-dependent mean value of the average texture of all images and the black level
+    int const ix = x % 6;
+    int const iy = y % 6;
+    float const black_level  = black_levels[ix + 6*iy];
+    float const mean_texture = mean_texture_buffer[ix + 6*iy] - black_level;
+    
+    // Weighed average of the 4 nearest pixels of the same color based on the average texture
+    float sum    = 0.0;
+    float total  = 0.0;
+    float weight = 0.0;
+    int dx       = 0;
+    int dy       = 0;
+    for (int off = 0; off < 4; off++) {
+        dx     = offset[iy][ix][off][0];
+        dy     = offset[iy][ix][off][1];
+        weight = 1.0/sqrt(pow(float(dx), 2) + pow(float(dy), 2));
         
-        // save weight in texture
+        total += weight;
+        float val = average_texture.read(uint2(x+dx, y+dy)).r;
+        sum   += weight * val;
+    }
+    sum /= total;
+    
+    // extract value of potential hot pixel from the average texture and divide by sum of surrounding pixels
+    float const pixel_value = average_texture.read(uint2(x, y)).r;
+    float const pixel_ratio = max(1.0,
+                                  pixel_value - black_level) / max(1.0,
+                                                                   sum - black_level);
+    
+    if (pixel_ratio >= hot_pixel_threshold & pixel_value >= 2 * mean_texture) {
+        // calculate weight for blending to have a smooth transition for not so obvious hot pixels
+        float const weight = 0.5f * correction_strength * min(2.0f,
+                                                              hot_pixel_multiplicator * (pixel_ratio - hot_pixel_threshold));
         hotpixel_weight_texture.write(weight, uint2(x, y));
     }
 }
@@ -457,6 +551,113 @@ kernel void prepare_texture_bayer(texture2d<uint, access::read> in_texture      
     float const black_level = black_levels[(gid.y%2)*2 + (gid.x%2)];
     
     // correct exposure
+    pixel_value = (pixel_value - black_level)*corr_factor + black_level;
+    pixel_value = max(pixel_value, 0.0f);
+    
+    out_texture.write(pixel_value, uint2(gid.x+pad_left, gid.y+pad_top));
+}
+
+/**
+ Same as the Bayer version, but accounting for the peculiarities of the XTrans sensor
+ */
+kernel void prepare_texture_xtrans(texture2d<uint, access::read> in_texture                  [[texture(0)]],
+                                   texture2d<float, access::read> hotpixel_weight_texture    [[texture(1)]],
+                                   texture2d<float, access::write> out_texture               [[texture(2)]],
+                                   device   float *black_levels   [[buffer(0)]],
+                                   constant int&  pad_left        [[buffer(1)]],
+                                   constant int&  pad_top         [[buffer(2)]],
+                                   constant int&  exposure_diff   [[buffer(3)]],
+                                   uint2 gid [[thread_position_in_grid]]) {
+    // A more accurate approach for the R and B would be to average out the two knight positions that have 1 distance between them, but that seems more computationally expensive.
+    // Lookup table for the relative positions of the closest 4 sub-pixels of the same color (🐷 approach)
+    int offset[6][6][4][2] = {
+        { // Row 0
+            {{ 0, -1}, { 1, -1}, { 1,  0}, {-1,  1}}, // G
+            {{ 0, -1}, { 1,  1}, {-1,  0}, {-1, -1}}, // G
+            {{ 1, -2}, { 2,  1}, { 0,  2}, {-2,  1}}, // B
+            {{ 0, -1}, { 1, -1}, { 1,  0}, {-1,  1}}, // G
+            {{ 0, -1}, { 1,  1}, {-1,  0}, {-1, -1}}, // G
+            {{ 1, -2}, { 2,  1}, { 0,  2}, {-2,  1}}  // R
+        },
+        { // Row 1
+            {{-1,  2}, {-2,  0}, {-1, -2}, { 2, -1}}, // B
+            {{ 1, -2}, { 2,  0}, { 1,  2}, {-2,  1}}, // R
+            {{ 1, -1}, { 1,  1}, {-1,  1}, {-1, -1}}, // G
+            {{ 2, -1}, { 2,  1}, {-1,  2}, {-2,  0}}, // R
+            {{ 1, -2}, { 2,  0}, { 1,  2}, {-2,  1}}, // B
+            {{ 1, -1}, { 1,  1}, {-1,  1}, {-1, -1}}  // G
+        },
+        { // Row 2
+            {{ 1,  0}, { 1,  1}, { 0,  1}, {-1,  1}}, // G
+            {{ 1, -1}, { 0,  1}, {-1,  1}, {-1,  0}}, // G
+            {{-2, -1}, { 0, -2}, { 2, -1}, { 1, -2}}, // B
+            {{ 1,  0}, { 1,  1}, { 0,  1}, {-1,  1}}, // G
+            {{ 1, -1}, { 0,  1}, {-1,  1}, {-1,  0}}, // G
+            {{-2, -1}, { 0, -2}, { 2, -1}, { 1, -2}}  // R
+        },
+        { // Row 3
+            {{ 0, -1}, { 1, -1}, { 1,  0}, {-1,  1}}, // G
+            {{ 0, -1}, { 1,  1}, {-1,  0}, {-1, -1}}, // G
+            {{ 1, -2}, { 2,  1}, { 0,  2}, {-2,  1}}, // R
+            {{ 0, -1}, { 1, -1}, { 1,  0}, {-1,  1}}, // G
+            {{ 0, -1}, { 1,  1}, {-1,  0}, {-1, -1}}, // G
+            {{ 1, -2}, { 2,  1}, { 0,  2}, {-2,  1}}  // B
+        },
+        { // Row 4
+            {{-1,  2}, {-2,  0}, {-1, -2}, { 2, -1}}, // R
+            {{ 1, -2}, { 2,  0}, { 1,  2}, {-2,  1}}, // B
+            {{ 1, -1}, { 1,  1}, {-1,  1}, {-1, -1}}, // G
+            {{ 2, -1}, { 2,  1}, {-1,  2}, {-2,  0}}, // B
+            {{ 1, -2}, { 2,  0}, { 1,  2}, {-2,  1}}, // R
+            {{ 1, -1}, { 1,  1}, {-1,  1}, {-1, -1}}  // G
+        },
+        { // Row 5
+            {{ 1,  0}, { 1,  1}, { 0,  1}, {-1,  1}}, // G
+            {{ 1, -1}, { 0,  1}, {-1,  1}, {-1,  0}}, // G
+            {{-2, -1}, { 0, -2}, { 2, -1}, { 1, -2}}, // R
+            {{ 1,  0}, { 1,  1}, { 0,  1}, {-1,  1}}, // G
+            {{ 1, -1}, { 0,  1}, {-1,  1}, {-1,  0}}, // G
+            {{-2, -1}, { 0, -2}, { 2, -1}, { 1, -2}}  // B
+        }
+    };
+    
+    // load args
+    int x = gid.x;
+    int y = gid.y;
+    int const ix = x % 6;
+    int const iy = y % 6;
+    
+    int const texture_width = in_texture.get_width();
+    int const texture_height = in_texture.get_height();
+    
+    float pixel_value = float(in_texture.read(gid).r);
+    
+    float const hotpixel_weight = hotpixel_weight_texture.read(gid).r;
+    
+    if (hotpixel_weight > 0.001f && x>=2 && x<texture_width-2 && y>=2 && y<texture_height-2) {
+        float sum    = 0.0;
+        float total  = 0.0;
+        float weight = 0.0;
+        int dx       = 0;
+        int dy       = 0;
+        for (int off = 0; off < 4; off++) {
+            dx     = offset[iy][ix][off][0];
+            dy     = offset[iy][ix][off][1];
+            weight = 1.0/sqrt(pow(float(dx), 2) + pow(float(dy), 2));
+            
+            total += weight;
+            float val = in_texture.read(uint2(x+dx, y+dy)).r;
+            sum   += weight * val;
+        }
+        sum /= total;
+        
+        // blend values and replace hot pixel value
+        pixel_value = hotpixel_weight*0.25f*sum + (1.0f-hotpixel_weight)*pixel_value;
+    }
+    
+    float const corr_factor = pow(2.0f, float(exposure_diff/100.0f));
+    float const black_level = black_levels[ix + 6*iy];
+    
     pixel_value = (pixel_value - black_level)*corr_factor + black_level;
     pixel_value = max(pixel_value, 0.0f);
     

--- a/burstphoto/texture/texture.swift
+++ b/burstphoto/texture/texture.swift
@@ -19,7 +19,7 @@ let sum_divide_buffer_state = try! device.makeComputePipelineState(function: mfl
 let fill_with_zeros_state = try! device.makeComputePipelineState(function: mfl.makeFunction(name: "fill_with_zeros")!)
 let find_hotpixels_state = try! device.makeComputePipelineState(function: mfl.makeFunction(name: "find_hotpixels")!)
 let normalize_texture_state = try! device.makeComputePipelineState(function: mfl.makeFunction(name: "normalize_texture")!)
-let prepare_texture_state = try! device.makeComputePipelineState(function: mfl.makeFunction(name: "prepare_texture")!)
+let prepare_texture_bayer_state = try! device.makeComputePipelineState(function: mfl.makeFunction(name: "prepare_texture_bayer")!)
 let sum_rect_columns_float_state = try! device.makeComputePipelineState(function: mfl.makeFunction(name: "sum_rect_columns_float")!)
 let sum_rect_columns_uint_state = try! device.makeComputePipelineState(function: mfl.makeFunction(name: "sum_rect_columns_uint")!)
 let sum_row_state = try! device.makeComputePipelineState(function: mfl.makeFunction(name: "sum_row")!)
@@ -210,8 +210,6 @@ func calculate_black_levels(for texture: MTLTexture, from_masked_areas masked_ar
         texture_descriptor.storageMode = .private
         let summed_y = device.makeTexture(descriptor: texture_descriptor)!
         summed_y.label = "\(texture.label!.components(separatedBy: ":")[0]): Summed in y for black level"
-        
-        
         
         // Sum along columns
         let command_buffer = command_queue.makeCommandBuffer()!
@@ -596,7 +594,7 @@ func normalize_texture(_ in_texture: MTLTexture, _ norm_texture: MTLTexture, _ n
 /// For example, if the reference image is taken at 0 EV and has a pixel value of 45 and image 2 is taken at 2 EV and has a pixel value of 200, the two values represent vastly different things. The pixel value of image 2 must be decreased by 2^-2 (200 x 2^-2 = 50) in order for the pixel values to be comparable.
 ///
 /// Inspired by https://ai.googleblog.com/2021/04/hdr-with-bracketing-on-pixel-phones.html
-func prepare_texture(_ in_texture: MTLTexture, _ hotpixel_weight_texture: MTLTexture, _ pad_left: Int, _ pad_right: Int, _ pad_top: Int, _ pad_bottom: Int, _ exposure_diff: Int, _ black_level: [[Int]], _ comp_idx: Int) -> MTLTexture {
+func prepare_texture(_ in_texture: MTLTexture, _ hotpixel_weight_texture: MTLTexture, _ pad_left: Int, _ pad_right: Int, _ pad_top: Int, _ pad_bottom: Int, _ exposure_diff: Int, _ black_level: [Int], _ mosaic_pattern_width: Int) -> MTLTexture {
 
     // always use pixel format float32 with increased precision that merging is performed with best possible precision    
     let out_texture_descriptor = MTLTextureDescriptor.texture2DDescriptor(pixelFormat: .r32Float, width: in_texture.width+pad_left+pad_right, height: in_texture.height+pad_top+pad_bottom, mipmapped: false)
@@ -606,24 +604,24 @@ func prepare_texture(_ in_texture: MTLTexture, _ hotpixel_weight_texture: MTLTex
     out_texture.label = "\(in_texture.label!.components(separatedBy: ":")[0]): Prepared"
     
     fill_with_zeros(out_texture)
+    
+    let black_levels_buffer = device.makeBuffer(bytes: black_level.map{ $0 == -1 ? Float32(0) : Float32($0)},
+                                                length: black_level.count * MemoryLayout<Float32>.size)!
         
     let command_buffer = command_queue.makeCommandBuffer()!
     command_buffer.label = "Prepare Texture"
     let command_encoder = command_buffer.makeComputeCommandEncoder()!
-    let state = prepare_texture_state
+    let state = prepare_texture_bayer_state
     command_encoder.setComputePipelineState(state)
     let threads_per_grid = MTLSize(width: in_texture.width, height: in_texture.height, depth: 1)
     let threads_per_thread_group = get_threads_per_thread_group(state, threads_per_grid)
     command_encoder.setTexture(in_texture, index: 0)
     command_encoder.setTexture(hotpixel_weight_texture, index: 1)
     command_encoder.setTexture(out_texture, index: 2)
-    command_encoder.setBytes([Int32(pad_left)], length: MemoryLayout<Int32>.stride, index: 0)
-    command_encoder.setBytes([Int32(pad_top)], length: MemoryLayout<Int32>.stride, index: 1)
-    command_encoder.setBytes([Int32(exposure_diff)], length: MemoryLayout<Int32>.stride, index: 2)
-    command_encoder.setBytes([Int32(black_level[comp_idx][0])], length: MemoryLayout<Int32>.stride, index: 3)
-    command_encoder.setBytes([Int32(black_level[comp_idx][1])], length: MemoryLayout<Int32>.stride, index: 4)
-    command_encoder.setBytes([Int32(black_level[comp_idx][2])], length: MemoryLayout<Int32>.stride, index: 5)
-    command_encoder.setBytes([Int32(black_level[comp_idx][3])], length: MemoryLayout<Int32>.stride, index: 6)
+    command_encoder.setBuffer(black_levels_buffer, offset: 0, index: 0)
+    command_encoder.setBytes([Int32(pad_left)], length: MemoryLayout<Int32>.stride, index: 1)
+    command_encoder.setBytes([Int32(pad_top)], length: MemoryLayout<Int32>.stride, index: 2)
+    command_encoder.setBytes([Int32(exposure_diff)], length: MemoryLayout<Int32>.stride, index: 3)
     command_encoder.dispatchThreads(threads_per_grid, threadsPerThreadgroup: threads_per_thread_group)
     command_encoder.endEncoding()
     command_buffer.commit()

--- a/burstphoto/texture/texture.swift
+++ b/burstphoto/texture/texture.swift
@@ -17,7 +17,8 @@ let crop_texture_state = try! device.makeComputePipelineState(function: mfl.make
 let divide_buffer_state = try! device.makeComputePipelineState(function: mfl.makeFunction(name: "divide_buffer")!)
 let sum_divide_buffer_state = try! device.makeComputePipelineState(function: mfl.makeFunction(name: "sum_divide_buffer")!)
 let fill_with_zeros_state = try! device.makeComputePipelineState(function: mfl.makeFunction(name: "fill_with_zeros")!)
-let find_hotpixels_state = try! device.makeComputePipelineState(function: mfl.makeFunction(name: "find_hotpixels")!)
+let find_hotpixels_bayer_state = try! device.makeComputePipelineState(function: mfl.makeFunction(name: "find_hotpixels_bayer")!)
+let find_hotpixels_xtrans_state = try! device.makeComputePipelineState(function: mfl.makeFunction(name: "find_hotpixels_xtrans")!)
 let normalize_texture_state = try! device.makeComputePipelineState(function: mfl.makeFunction(name: "normalize_texture")!)
 let prepare_texture_bayer_state = try! device.makeComputePipelineState(function: mfl.makeFunction(name: "prepare_texture_bayer")!)
 let sum_rect_columns_float_state = try! device.makeComputePipelineState(function: mfl.makeFunction(name: "sum_rect_columns_float")!)
@@ -237,7 +238,6 @@ func calculate_black_levels(for texture: MTLTexture, from_masked_areas masked_ar
         command_encoder.setBuffer(sum_buffer, offset: 0, index: 0)
         command_encoder.setBytes([Int32(summed_y.width)], length: MemoryLayout<Int32>.stride, index: 1)
         command_encoder.setBytes([Int32(mosaic_pattern_width)], length: MemoryLayout<Int32>.stride, index: 2)
-        // TODO: Should this have the same number of threads? I think it should only be 1 thread.
         let threads_per_grid_x = MTLSize(width: mosaic_pattern_width, height: mosaic_pattern_width, depth: 1)
         command_encoder.dispatchThreads(threads_per_grid_x, threadsPerThreadgroup: threads_per_thread_group)
         command_encoder.endEncoding()
@@ -451,18 +451,27 @@ func fill_with_zeros(_ texture: MTLTexture) {
 }
 
 
+/// Find hotpixels based on the idea that they will be the same pixels in all frames of the burst.
 func find_hotpixels(_ textures: [MTLTexture], _ hotpixel_weight_texture: MTLTexture, _ black_level: [[Int]], _ ISO_exposure_time: [Double], _ noise_reduction: Double, _ mosaic_pattern_width: Int) {
     
-    var correction_strength = 1.0
+    if mosaic_pattern_width != 2 || mosaic_pattern_width != 6 {
+        return
+    }
     
     // calculate hot pixel correction strength based on ISO value, exposure time and number of frames in the burst
+    var correction_strength: Double
     if ISO_exposure_time[0] > 0.0 {
+        correction_strength = ISO_exposure_time.reduce(0, +)
         
-        correction_strength = 0.0
-        for comp_idx in 0..<textures.count {
-            correction_strength += ISO_exposure_time[comp_idx]
-        }
-        correction_strength = (min(max(correction_strength/sqrt(Double(textures.count)) * (noise_reduction==23.0 ? 0.25 : 1.00), 5.0), 80.0)-5.0)/75.0
+        correction_strength = ( // TODO: This needs an explanation
+            min(80,
+                max(5.0,
+                    correction_strength/sqrt(Double(textures.count)) * (noise_reduction==23.0 ? 0.25 : 1.00)
+                )
+            ) - 5.0
+        ) / 75.0
+    } else {
+        correction_strength = 1.0
     }
     
     // only apply hot pixel correction if correction strength is larger than 0.001
@@ -478,7 +487,6 @@ func find_hotpixels(_ textures: [MTLTexture], _ hotpixel_weight_texture: MTLText
         
         // iterate over all images
         for comp_idx in 0..<textures.count {
-            
             add_texture(textures[comp_idx], average_texture, textures.count)
         }
         
@@ -488,40 +496,49 @@ func find_hotpixels(_ textures: [MTLTexture], _ hotpixel_weight_texture: MTLText
                                                mosaic_pattern_width: mosaic_pattern_width)
         
         // standard parameters if black level is not available / available
-        let hot_pixel_threshold     = (black_level[0][0] == -1) ? 1.0 : 2.0
         let hot_pixel_multiplicator = (black_level[0][0] == -1) ? 2.0 : 1.0
-        
-        // calculate mean black level for each color channel
-        var black_level0 = 0.0
-        var black_level1 = 0.0
-        var black_level2 = 0.0
-        var black_level3 = 0.0
-        
-        for comp_idx in 0..<textures.count {
-            black_level0 += (black_level[comp_idx][0] == -1) ? 0.0 : Double(black_level[comp_idx][0])
-            black_level1 += (black_level[comp_idx][1] == -1) ? 0.0 : Double(black_level[comp_idx][1])
-            black_level2 += (black_level[comp_idx][2] == -1) ? 0.0 : Double(black_level[comp_idx][2])
-            black_level3 += (black_level[comp_idx][3] == -1) ? 0.0 : Double(black_level[comp_idx][3])
+        var hot_pixel_threshold     = (black_level[0][0] == -1) ? 1.0 : 2.0
+        // X-Trans sensor has more spacing between nearest pixels of same color, need a more relaxed threshold.
+        if mosaic_pattern_width == 6 {
+            hot_pixel_threshold *= 1.4
         }
         
-        // determine hot pixel probability for each pixel in the average texture
+        // Calculate mean black level for each color channel
+        var black_levels_mean = Array(repeating: Float32(0), count: mosaic_pattern_width*mosaic_pattern_width)
+        if black_level[0][0] != 1 {
+            for channel_idx in 0..<mosaic_pattern_width*mosaic_pattern_width {
+                for img_idx in 0..<textures.count {
+                    black_levels_mean[channel_idx] += Float32(black_level[img_idx][channel_idx])
+                }
+                black_levels_mean[channel_idx] /= Float32(textures.count)
+            }
+        }
+        let black_levels_buffer = device.makeBuffer(bytes: black_levels_mean, length: MemoryLayout<Float32>.size * black_levels_mean.count)!
+             
         let command_buffer = command_queue.makeCommandBuffer()!
-        command_buffer.label = "Hotpixel Detection"
+        command_buffer.label = "Finding hotpixels"
         let command_encoder = command_buffer.makeComputeCommandEncoder()!
-        let state = find_hotpixels_state
+        let state: MTLComputePipelineState
+        switch mosaic_pattern_width {
+            case 2:
+                state = find_hotpixels_bayer_state
+            case 6:
+                state = find_hotpixels_xtrans_state
+            default:
+                return
+        }
         command_encoder.setComputePipelineState(state)
+        // -4 in width and height represent that hotpixel correction is not applied on a 2-pixel wide border around the image.
+        // This is done so that the algorithm is simpler and comparing neighbours don't have to handle the edge cases.
         let threads_per_grid = MTLSize(width: average_texture.width-4, height: average_texture.height-4, depth: 1)
         let threads_per_thread_group = get_threads_per_thread_group(state, threads_per_grid)
         command_encoder.setTexture(average_texture, index: 0)
         command_encoder.setTexture(hotpixel_weight_texture, index: 1)
         command_encoder.setBuffer(mean_texture_buffer, offset: 0, index: 0)
-        command_encoder.setBytes([Float32(black_level0/Double(textures.count))], length: MemoryLayout<Float32>.stride, index: 1)
-        command_encoder.setBytes([Float32(black_level1/Double(textures.count))], length: MemoryLayout<Float32>.stride, index: 2)
-        command_encoder.setBytes([Float32(black_level2/Double(textures.count))], length: MemoryLayout<Float32>.stride, index: 3)
-        command_encoder.setBytes([Float32(black_level3/Double(textures.count))], length: MemoryLayout<Float32>.stride, index: 4)
-        command_encoder.setBytes([Float32(hot_pixel_threshold)], length: MemoryLayout<Float32>.stride, index: 5)
-        command_encoder.setBytes([Float32(hot_pixel_multiplicator)], length: MemoryLayout<Float32>.stride, index: 6)
-        command_encoder.setBytes([Float32(correction_strength)], length: MemoryLayout<Float32>.stride, index: 7)
+        command_encoder.setBuffer(black_levels_buffer, offset: 0, index: 1)
+        command_encoder.setBytes([Float32(hot_pixel_threshold)],     length: MemoryLayout<Float32>.stride, index: 2)
+        command_encoder.setBytes([Float32(hot_pixel_multiplicator)], length: MemoryLayout<Float32>.stride, index: 3)
+        command_encoder.setBytes([Float32(correction_strength)],     length: MemoryLayout<Float32>.stride, index: 4)
         command_encoder.dispatchThreads(threads_per_grid, threadsPerThreadgroup: threads_per_thread_group)
         command_encoder.endEncoding()
         command_buffer.commit()


### PR DESCRIPTION
 The PR does not negatively impact the Bayer images, and seems to produce only minor differences on the few XTrans images that I have access to. Importantly, the hot pixel suppression does not eat any of the stars from the one burst of XTrans images I have access to.
 
 This will likely require further work in the future to properly tune the strength of the filtering, but that will require many more photos.

Depends on #47