### PR TITLE
Fix off-by-one issue introduced in #38

### DIFF
--- a/burstphoto/merge/frequency.swift
+++ b/burstphoto/merge/frequency.swift
@@ -195,7 +195,7 @@ func align_merge_frequency_domain(progress: ProcessingProgress, ref_idx: Int, mo
         // reduce potential artifacts at tile borders
         reduce_artifacts_tile_border(output_texture, ref_texture_rgba, tile_info_merge, black_level[ref_idx])
         // convert back to the 2x2 pixel structure and crop to original size
-        output_texture = convert_to_bayer(output_texture, pad_left-crop_merge_x, pad_right-crop_merge_x, pad_top-crop_merge_y, pad_bottom-crop_merge_y)
+        output_texture = crop_texture(convert_to_bayer(output_texture), pad_left-crop_merge_x, pad_right-crop_merge_x, pad_top-crop_merge_y, pad_bottom-crop_merge_y)
         
         // add output texture to the final texture to collect all textures of the four iterations
         add_texture(output_texture, final_texture, 1)

--- a/burstphoto/texture/texture.metal
+++ b/burstphoto/texture/texture.metal
@@ -365,14 +365,12 @@ kernel void convert_float_to_uint16(texture2d<float, access::read>  in_texture  
 
 kernel void convert_to_bayer(texture2d<float, access::read> in_texture [[texture(0)]],
                              texture2d<float, access::write> out_texture [[texture(1)]],
-                             constant int& pad_left [[buffer(0)]],
-                             constant int& pad_top [[buffer(1)]],
                              uint2 gid [[thread_position_in_grid]]) {
     
     int const x = gid.x*2;
     int const y = gid.y*2;
     
-    float4 const color_value = in_texture.read(uint2(gid.x+pad_left, gid.y+pad_top));
+    float4 const color_value = in_texture.read(uint2(gid.x, gid.y));
      
     out_texture.write(color_value[0], uint2(x,   y));
     out_texture.write(color_value[1], uint2(x+1, y));


### PR DESCRIPTION
Part of #38 combined the conversion from a .RGBA texture (MxNx4) to a .R texture (2Mx2N) with the subsequent cropping step. The RGBA texture is used since it conveniently stores all 4 sub-pixels of a Bayer CFA at one spatial coordinate using 4-vector while also providing performance benefits. The conversion back to the .R texture is done since the final image is a .R texture (a flattened Bayered image).

This had a subtle bug I missed the first time around in the following lines:
```Metal
command_encoder.setBytes([Int32(pad_left/2)], length: MemoryLayout<Int32>.stride, index: 0)
command_encoder.setBytes([Int32(pad_top/2)], length: MemoryLayout<Int32>.stride, index: 1)
```
Nothing ensure that `pad_left` and `pad_top` inside `convert_to_bayer` is a multiple of 2. Originally, as used by `crop_texture` this was not a problem since `pad_left` and `pad_top` were used directly to index into the .R texture so the division by 2 was not needed. The division by 2 is needed since the RGBA texture indexes by Bayer CFA repeat units, rather than individual sub-pixels (i.e. RGBG instead of R, G, B, or G).

Certain images I've found end up requiring `pad_left` and/or `pad_top` to be odd, meaning that the indexing needing is no longer aligned and couldn't be performed in the .RGBA image.

Profiling the change, the difference in speed between doing the steps sequentially (as previously done) versus together did not yield a measurable difference in performance. So rather than fiddle with the padding math, I undid the portion of the PR that changed how `convert_to_bayer` worked.