### PR TITLE
FIX: White level would become invalid when using 16-bit output option.

### DIFF
--- a/burstphoto/denoise.swift
+++ b/burstphoto/denoise.swift
@@ -228,9 +228,10 @@ func perform_denoising(image_urls: [URL], progress: ProcessingProgress, merging_
     // apply scaling to 16 bit
     let scale_to_16bit = (output_bit_depth=="16Bit" && mosaic_pattern_width == 2 && exposure_control != "Off")
     let factor_16bit = (scale_to_16bit ? Int(pow(2.0, 16.0-ceil(log2(Double(white_level[ref_idx]))))+0.5) : 1)
+    let white_level_scaled = min(65535, factor_16bit*white_level[ref_idx])
 
     // convert final image to 16 bit integer
-    let output_texture_uint16 = convert_float_to_uint16(final_texture, (white_level[ref_idx] == -1 ? 1000000 : factor_16bit*white_level[ref_idx]), black_level[ref_idx], factor_16bit, mosaic_pattern_width)
+    let output_texture_uint16 = convert_float_to_uint16(final_texture, (white_level[ref_idx] == -1 ? 1000000 : white_level_scaled), black_level[ref_idx], factor_16bit, mosaic_pattern_width)
       
     print("Time to align+merge all images: ", Float(DispatchTime.now().uptimeNanoseconds - t) / 1_000_000_000)
     t = DispatchTime.now().uptimeNanoseconds
@@ -264,7 +265,7 @@ func perform_denoising(image_urls: [URL], progress: ProcessingProgress, merging_
     }
     
     // save the output image
-    try texture_to_dng(output_texture_uint16, ref_dng_url, out_url, (scale_to_16bit ? Int32(factor_16bit*white_level[ref_idx]) : -1))
+    try texture_to_dng(output_texture_uint16, ref_dng_url, out_url, (scale_to_16bit ? Int32(white_level_scaled) : -1))
     
     // check if dng converter is installed
     if dng_converter_present {


### PR DESCRIPTION
The current code did not check that the white level resulting from `factor_16bit*white_level[ref_idx]` would be in the range of [0, 2^16 -1]. On the Canon R5 MkII this calculation resulted in a white level of 65,536 (i.e. 2^16) which is too big to fit inside a uint16. The actual scaling code inside `convert_float_to_uint16` properly clamps to uin16 range, but the values sent to `texture_to_dng` did not, resulting in a produced DNG being written which cannot be opened, not even by the dng convertor since it fails validation.